### PR TITLE
Tutorial: fixed URL and command

### DIFF
--- a/docs/tutorials/deploy_example.rst
+++ b/docs/tutorials/deploy_example.rst
@@ -26,7 +26,7 @@ the K8S_HELM_REGISTRY reference with your account details::
     export K8S_HELM_REGISTRY=ghcr.io/<your account or organization goes here>
 
     # get the helper functions
-    wget -q https://raw.githubusercontent.com/epics-containers/k8s-epics-utils/main/epics-dev-image/home/bin/kube-functions.sh
+    wget -q https://raw.githubusercontent.com/epics-containers/k8s-epics-utils/main/kube-functions.sh
     source kube-functions.sh
 
 Deploy an IOC Version

--- a/docs/tutorials/useful_k8s.rst
+++ b/docs/tutorials/useful_k8s.rst
@@ -46,9 +46,15 @@ Then create the admin user and role by executing the following:
       namespace: kubernetes-dashboard
     EOF
 
-get a token for the user and copy the token into your clipboard::
+Get a token for the user and copy the token into your clipboard.
+
+On k3s v1.23 and older::
 
     kubectl -n kubernetes-dashboard describe secret admin-user-token | grep '^token'
+
+On k3s v1.24 and newer::
+
+    kubectl -n kubernetes-dashboard create token admin-user
 
 Use kubectl to start a proxy that will forward HTTP requests to your cluster::
 


### PR DESCRIPTION
A couple fixes for the tutorial:
* [kube-functions.sh](https://raw.githubusercontent.com/epics-containers/k8s-epics-utils/main/kube-functions.sh) was relocated in the k8s-epics-utils repository
* k3s token generation differs significantly on v1.23 vs 1.24 ([ref](https://docs.k3s.io/installation/kube-dashboard#obtain-the-bearer-token))