### PR TITLE
Correct inconsistent beamline naming

### DIFF
--- a/docs/user/tutorials/dev_container.rst
+++ b/docs/user/tutorials/dev_container.rst
@@ -290,7 +290,7 @@ Try the following:
 
    cd /epics/ioc
    rm -r config
-   ln -s /repos/bl02t/iocs/bl02t-ea-ioc-02/config .
+   ln -s /repos/bl01t/iocs/bl01t-ea-ioc-02/config .
    # check the ln worked
    ls -l config
    ./start.sh

--- a/docs/user/tutorials/ioc_changes1.rst
+++ b/docs/user/tutorials/ioc_changes1.rst
@@ -31,7 +31,7 @@ Make the following changes in your test IOC config folder
 
    .. code-block:: text
 
-      record(ai, "BL02T-EA-IOC-01:TEST") {
+      record(ai, "BL01T-EA-IOC-01:TEST") {
          field(DESC, "Test record")
          field(DTYP, "Soft Channel")
          field(SCAN, "Passive")
@@ -67,7 +67,7 @@ from another terminal (VSCode menus -> Terminal -> New Terminal) like so:
 
 .. code-block:: bash
 
-   caget BL02T-EA-IOC-02:TEST
+   caget BL01T-EA-IOC-02:TEST
 
 If you see the value 1 then your change is working.
 

--- a/docs/user/tutorials/ioc_changes1.rst
+++ b/docs/user/tutorials/ioc_changes1.rst
@@ -31,7 +31,7 @@ Make the following changes in your test IOC config folder
 
    .. code-block:: text
 
-      record(ai, "BL01T-EA-IOC-01:TEST") {
+      record(ai, "BL01T-EA-IOC-02:TEST") {
          field(DESC, "Test record")
          field(DTYP, "Soft Channel")
          field(SCAN, "Passive")


### PR DESCRIPTION
"Changing the IOC Instance" seems to be broken (`./start.sh` does not result in output of `dbLoadRecords(config/extra.db)`. It seems that the instructions creates a softlink pointing to a `bl02t` which does not exist