### PR TITLE
Include port in CA addr list in example

### DIFF
--- a/docs/tutorials/launch_example.md
+++ b/docs/tutorials/launch_example.md
@@ -43,7 +43,7 @@ You can now try out the following commands to interact with the beamline.
 
 ```bash
 # use caget/put locally
-export EPICS_CA_ADDR_LIST=127.0.0.1
+export EPICS_CA_ADDR_LIST=127.0.0.1:5094
 caget BL01T-DI-CAM-01:DET:Acquire_RBV
 
 # OR if you don't have caget/put locally then use one of the containers instead:


### PR DESCRIPTION
The port is set by the environment.sh script from the previous step but
is overridden in the longer example. Without the port, none of the PVs
are accessible.
