### PR TITLE
Recommend podman throughout, consolidate docker onto one page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,6 +52,8 @@
         "--net=host",
         // Make sure SELinux does not disable with access to host filesystems like tmp
         "--security-opt=label=disable",
+        // Allow claude-sandbox to isolate the network see
+        // https://gilesknap.github.io/claude-sandbox/how-to/network-egress-jail.html
         "--device=/dev/net/tun"
     ],
     "mounts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,7 +51,8 @@
         // Allow the container to access the host X11 display and EPICS CA
         "--net=host",
         // Make sure SELinux does not disable with access to host filesystems like tmp
-        "--security-opt=label=disable"
+        "--security-opt=label=disable",
+        "--device=/dev/net/tun"
     ],
     "mounts": [
         // Mount in the user terminal config folder so it can be edited

--- a/docs/explanations/decisions/0005-python-scripting.md
+++ b/docs/explanations/decisions/0005-python-scripting.md
@@ -12,7 +12,7 @@ Inside the container, we use the `ibek` tool for scripting. Outside we
 use `ec` from `epics-containers-cli`.
 
 Much of what these tools do is
-call command line tools like `docker`, `helm`, `kubectl`, compilers,
+call command line tools like `podman`, `helm`, `kubectl`, compilers,
 etc. This seems like a natural fit for bash scripts.
 
 These features were originally implemented in bash but were converted to

--- a/docs/explanations/epics_protocols.md
+++ b/docs/explanations/epics_protocols.md
@@ -30,7 +30,7 @@ To get clients and servers connected we can use 3 approaches:
 
 Using Host Network or the same container network for client and host is compatible with both PVA and CA protocols.
 
-For podman and docker networks this is true even for UDP broadcast.
+For podman networks this is true even for UDP broadcast.
 
 For the majority of Kubernetes CNI's the broadcast does not work across pods. It is quite possible that broadcast within pods would work as this is equivalent to 'same container network'. However this would make management of large numbers of IOCs far more of a manual task.
 

--- a/docs/explanations/introduction.md
+++ b/docs/explanations/introduction.md
@@ -23,10 +23,10 @@ and their APIs such that container images can be interchanged between
 different frameworks.
 
 Thus, in this project we develop, build and test our container images
-using docker or podman but the images can be run under Kubernetes' own
+using podman but the images can be run under Kubernetes' own
 container runtime.
 
-This article does a good job of explaining the relationship between docker /
+This article does a good job of explaining the relationship between
 containers and Kubernetes <https://semaphoreci.com/blog/kubernetes-vs-docker>
 
 An important outcome of using containers is that you can alter the
@@ -94,9 +94,9 @@ implementing these features:
 - Debug an IOC by starting a bash shell inside it's container
 
 ### Kubernetes Alternatives
-If you do not wish to maintain a Kubernetes cluster then you could simply install IOCs directly into the local docker or podman instance on each server. Instead of using Kubernetes and Helm, you can use docker compose to manage such IOC instances. But this is just an example, epics-containers is intended to be modular so that you can make use of any parts of it without adopting the whole framework as used at DLS.
+If you do not wish to maintain a Kubernetes cluster then you could simply install IOCs directly into the local podman instance on each server. Instead of using Kubernetes and Helm, you can use docker compose to manage such IOC instances. But this is just an example, epics-containers is intended to be modular so that you can make use of any parts of it without adopting the whole framework as used at DLS.
 
-We provide a template services project that uses docker compose with docker or podman as the runtime engine. Docker compose allows us to describe a set of IOCs and other services for each beamline server, similar to the way Helm does. Where a beamline has multiple servers, the distribution of IOCs across those servers could be managed by maintaining a separate docker-compose file for each server in the root of the services repository.
+We provide a template services project that uses docker compose with podman as the runtime engine. Docker compose allows us to describe a set of IOCs and other services for each beamline server, similar to the way Helm does. Where a beamline has multiple servers, the distribution of IOCs across those servers could be managed by maintaining a separate docker-compose file for each server in the root of the services repository.
 
 If you choose to use this approach then you may find it useful to have another tool for viewing and managing the set of containers you have deployed across your beamline servers. There are various solutions for this, one that has been tested with **epics-containers** is Portainer <https://www.portainer.io/>. Portainer is a paid for product that provides excellent visibility and control of your containers through a web interface. Such a tool could allow you to centrally manage the containers on all your servers.
 
@@ -115,7 +115,7 @@ Helm has functions to deploy Charts to a cluster and manage multiple versions
 of the Chart within the cluster.
 
 It also supports registries for storing version history of Charts,
-much like docker.
+much like a container image registry.
 
 In this project we use Helm Charts to define and deploy IOC instances. IOCs are grouped into a {any}`services-repo`. Typical services repositories represent a beamline or accelerator technical area but any grouping is allowed. Each of these repositories holds the Helm Charts for its IOC Instances and any other services we require. Each IOC instance folder need only contain:
 

--- a/docs/explanations/rootless.md
+++ b/docs/explanations/rootless.md
@@ -1,6 +1,9 @@
-# Rootless vs Rootfull
+(rootless)=
+# Rootless vs Rootful
 
-epics-containers is intended to support both docker and podman. Docker is rootfull by default but also supports rootless operation. Podman is rootless by default but also supports rootfull operation.
+epics-containers recommends running containers **rootless**. This is why we
+recommend `podman`, which is rootless by default. (`docker` is rootful by
+default but also supports a rootless mode - see {any}`using-docker`.)
 
 Advantages of rootless operation include:
 
@@ -10,69 +13,29 @@ Advantages of rootless operation include:
 - Developer containers: rootless containers can be 'root' inside the container, but not on the host.
 - Simplicity: no need to switch users in Dockerfiles - just stay as root and use psuedo-root during runtime. This maps nicely to using the same container in Kubernetes where control of the user id is up to the cluster.
 
-Advantages of rootfull operation include:
+Advantages of rootful operation include:
 
 - networking: you can create rootable bridge networks that can be accessed from the host
 - power: you can give containers privileged capabilities that the user would not normally have
 
-The advantages of rootless are ideal for developing and executing IOCs.
+The advantages of rootless are ideal for developing and executing IOCs, which
+is why `podman` (rootless) is the recommended container engine throughout this
+documentation.
 
-## Current situation
+## Why podman is recommended
 
-At present epics-containers requires slightly different configuration for docker and podman. However these differences are really because of the rootfull vs rootless distinction. Those distinctions for docker (rootful) are:
+Because `podman` is rootless by default it gives the simplest and most secure
+experience:
 
-- EC_REMOTE_USER: must be set so that developer containers run as the current user
-- Permissions on the files inside the developer container need to be set with *sudo chown* at startup
-- Developer containers will sometimes have issues with git repo permissions
-- docker compose deployed IOCs do run as root and write any generated files as root in host mounted folders (this needs fixing)
-- UIDGID is required to be passed to the compose file for phoebus to make sure it runs as the correct user (but would not be needed at all for rootless)
+- when you appear to be `root` inside a `podman` container you are really
+  running as your own host user id, so any host files you write are owned by
+  you;
+- developer containers can run as `root` inside the container without any extra
+  configuration;
+- there is no need to set `EC_REMOTE_USER`, fix file ownership with `sudo chown`,
+  or pass a special `UIDGID` to the compose file.
 
-## Proposed solution
-
-We should mantate the use of rootless for epics-containers. This will make the configuration simpler and more secure.
-
-A potential issue with this is that developers who use docker for other purposes may need to use rootfull as well.
-
-This would therefore be accetable if it is easy to switch between rootfull and rootless operation. The next section shows how I have done this with docker on Ubuntu 24.04, I would guess that this will work on other distros but this needs to be verified.
-
-## Configure Docker with rootless/rootfull operation
-
-Note that some fixes to epics-containers 'Current Situtation' are required if you switch to rootless operation - we can remove some of the config requirements.
-
-These instructions worked for me on Ubuntu 24.04. Assume docker default install is already done and is at version 27.2.0.
-
-1. docker install comes with a script to set up rootless operation. We use --force to tell it to run even though rootfull is already set up.
-
-    ```bash
-    sudo dockerd-rootless-setuptool.sh --force
-    ```
-
-1. The script may get errors and explain how to get around them. In my case it asked me to run this:
-    ```bash
-    sudo sh -eux <<EOF
-    # Install newuidmap & newgidmap binaries
-    apt-get install -y uidmap
-    EOF
-    ```
-
-1. Make sure the rootfull service is still running (may not need this step).
-
-    ```bash
-    sudo systemctl enable --now docker.service docker.socket
-    ```
-
-1. Now you can switch between both by changing the environment variable DOCKER_HOST.
-
-1. To switch to rootless:
-
-    ```bash
-    export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
-    docker ps -a
-    ```
-
-1. To switch back to rootfull:
-
-    ```bash
-    export DOCKER_HOST=unix:///var/run/docker.sock
-    docker ps -a
-    ```
+If you choose to use `docker` instead, running it rootless gives you the same
+benefits. Running `docker` rootful is also supported, but a few extra
+configuration steps are then required. Both options are described in
+{any}`using-docker`.

--- a/docs/how-to/compose-quickstart.md
+++ b/docs/how-to/compose-quickstart.md
@@ -51,6 +51,8 @@ systemctl enable --user podman.socket --now
 
 Add this to your `~/.profile` and logout and back in:
 ```bash
-export PATH=/dls_sw/apps/docker-compose/2.33.1/bin/:$PATH
+export PATH=/dls_sw/apps/docker-compose/5.1.4/bin/:$PATH
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
 ```
+
+NOTE: re above. You should first do `ls /dls_sw/apps/docker-compose/` to check which is the most recent version of docker-compose available. Use that version in preference to the example above.

--- a/docs/how-to/compose-quickstart.md
+++ b/docs/how-to/compose-quickstart.md
@@ -1,11 +1,11 @@
 (quickstart)=
 # Docker Compose Quickstart
 
-Here are some minimal setup instructions to get you up and running with docker-compose and a container runtime on any platform.
+Here are some minimal setup instructions to get you up and running with docker-compose and a container runtime on any platform. We recommend `podman` as the container runtime; if you would rather use `docker` see {any}`using-docker`.
 
-## Docker Already Installed
+## Podman Already Installed
 
-If you have any Linux distribution with Docker installed you are all set.
+If you have any Linux distribution with podman and docker-compose installed you are all set.
 
 (linux-installation)=
 ## Linux
@@ -53,5 +53,4 @@ Add this to your `~/.profile` and logout and back in:
 ```bash
 export PATH=/dls_sw/apps/docker-compose/2.33.1/bin/:$PATH
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
-alias docker=podman
 ```

--- a/docs/how-to/debug.md
+++ b/docs/how-to/debug.md
@@ -26,24 +26,24 @@ Add the phrase 'deliberate_error' to the top of the `ioc.yaml` file. Then try to
 ec -v deploy-local services/bl01t-ea-test-02
 ```
 
-You should see something like this (for docker users - docker users will see something similar):
+You should see something like this:
 
 <pre>$ ec -v deploy-local services/bl01t-ea-test-02
-<font color="#5F8787">docker --version</font>
-<font color="#5F8787">docker buildx version</font>
-Deploy TEMPORARY version 2024.2.17-b8.30 from /home/giles/tutorial/bl01t/services/bl01t-ea-test-02 to the local docker instance
+<font color="#5F8787">podman --version</font>
+<font color="#5F8787">podman version</font>
+Deploy TEMPORARY version 2024.2.17-b8.30 from /home/giles/tutorial/bl01t/services/bl01t-ea-test-02 to the local podman instance
 Are you sure ? [y/N]: y
-<font color="#5F8787">docker stop -t0 bl01t-ea-test-02</font>
-<font color="#5F8787">docker rm -f bl01t-ea-test-02</font>
-<font color="#5F8787">docker volume rm -f bl01t-ea-test-02_config</font>
-<font color="#5F8787">docker volume create bl01t-ea-test-02_config</font>
-<font color="#5F8787">docker rm -f busybox</font>
-<font color="#5F8787">docker container create --name busybox -v bl01t-ea-test-02_config:/copyto busybox</font>
-<font color="#5F8787">docker cp /home/giles/tutorial/bl01t/services/bl01t-ea-test-02/config/ioc.yaml busybox:copyto</font>
-<font color="#5F8787">docker rm -f busybox</font>
-<font color="#5F8787">docker run -dit --net host --restart unless-stopped -l is_IOC=true -l version=2024.2.17-b8.30 -v bl01t-ea-test-02_config:/epics/ioc/config/ -e IOC_NAME=bl01t-ea-test-02  --name bl01t-ea-test-02 ghcr.io/epics-containers/ioc-adsimdetectorruntime:2024.2.2</font>
+<font color="#5F8787">podman stop -t0 bl01t-ea-test-02</font>
+<font color="#5F8787">podman rm -f bl01t-ea-test-02</font>
+<font color="#5F8787">podman volume rm -f bl01t-ea-test-02_config</font>
+<font color="#5F8787">podman volume create bl01t-ea-test-02_config</font>
+<font color="#5F8787">podman rm -f busybox</font>
+<font color="#5F8787">podman container create --name busybox -v bl01t-ea-test-02_config:/copyto busybox</font>
+<font color="#5F8787">podman cp /home/giles/tutorial/bl01t/services/bl01t-ea-test-02/config/ioc.yaml busybox:copyto</font>
+<font color="#5F8787">podman rm -f busybox</font>
+<font color="#5F8787">podman run -dit --net host --restart unless-stopped -l is_IOC=true -l version=2024.2.17-b8.30 -v bl01t-ea-test-02_config:/epics/ioc/config/ -e IOC_NAME=bl01t-ea-test-02  --name bl01t-ea-test-02 ghcr.io/epics-containers/ioc-adsimdetectorruntime:2024.2.2</font>
 76c2834dac805780b3329af91c332abb90fb2692a510c11b888b82e48f60b44f
-<font color="#5F8787">docker ps -f name=bl01t-ea-test-02 --format &apos;{{.Names}}&apos;</font>
+<font color="#5F8787">podman ps -f name=bl01t-ea-test-02 --format &apos;{{.Names}}&apos;</font>
 </pre>
 
 Now if you try these commands you should see that the IOC instance keeps restarting and that the logs show an error:
@@ -59,7 +59,7 @@ Now you can tell `ec` to stop the IOC instance and then run it in a way that you
 
 ```bash
 ec stop bl01t-ea-test-02
-docker run --entrypoint bash -it --net host -l is_IOC=true -l version=2024.2.17-b8.30 -v bl01t-ea-test-02_config:/epics/ioc/config/ -e IOC_NAME=bl01t-ea-test-02  --name bl01t-ea-test-02-debug ghcr.io/epics-containers/ioc-adsimdetectorruntime:2024.2.2
+podman run --entrypoint bash -it --net host -l is_IOC=true -l version=2024.2.17-b8.30 -v bl01t-ea-test-02_config:/epics/ioc/config/ -e IOC_NAME=bl01t-ea-test-02  --name bl01t-ea-test-02-debug ghcr.io/epics-containers/ioc-adsimdetectorruntime:2024.2.2
 ```
 
 You should now be in a shell inside the container. You can look at the files and run the IOC instance manually to see what the error is. You can re-run the IOC instance multiple times and you can even install your favourite editor or debugging tools.
@@ -79,10 +79,10 @@ vim /epics/ioc/config/ioc.yaml
 ./start.sh
 ```
 
-When you are done you can exit the container with `ctrl-d` and then remove it (or you can keep it around for later and restart it with `docker start -i bl01t-ea-test-02-debug`):
+When you are done you can exit the container with `ctrl-d` and then remove it (or you can keep it around for later and restart it with `podman start -i bl01t-ea-test-02-debug`):
 
 ```bash
-docker rm -f bl01t-ea-test-02-debug
+podman rm -f bl01t-ea-test-02-debug
 ```
 
 You can now apply the fix you made to the local filesystem and retry the deployment.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -1,26 +1,164 @@
-Working with Docker
-===================
+(using-docker)=
 
-DLS is a `podman` shop and therefore more testing is done with `podman` than `docker` as the container CLI used with developer containers. `podman` works extremely well with developer containers, but `docker` needs a little more work sometimes.
+Using Docker Instead of Podman
+==============================
 
-The primary difference is that `podman` does not require root access and `docker` does. When inside a `podman` container you appear to be root but you are running as your own host user id. When you write to any host mounted files you will be doing so with your host user permissions. In a docker container any host files written will be owned by the user id that the container is running as.
+epics-containers recommends `podman` as the container engine for the
+tutorials and for production use. The rest of this documentation refers to
+`podman` throughout. This page is the **single place** that describes how to
+use `docker` instead. If you would prefer to use `docker`, read this page and
+then continue with the rest of the documentation, mentally substituting
+`docker` wherever you see `podman`.
 
-Therefore:
-- It is better not to run `docker` containers as root.
-- It is easiest to run `podman` containers as root for simplicity.
+`podman` and `docker` share (almost) the same command line interface, so every
+`podman ...` command in these tutorials has an identical `docker ...`
+equivalent. For convenience you can add an alias so that you can copy and paste
+the `podman` commands verbatim:
 
-We do fully support `docker`, please report any issues you find.
+```bash
+# place this in $HOME/.bashrc (or $HOME/.zshrc for zsh users)
+alias podman=docker
+```
 
-If you would like to use docker in rootless mode then it is almost identical to podman and the following instructions are NOT required. To switch to rootless mode see the description of `dockerd-rootless-setuptool.sh` in  [these instructions](https://docs.docker.com/engine/security/rootless/#install).
+:::{note}
+We continue to use **docker compose** with both engines. `docker compose` is the
+multi-container orchestration tool used for the local-deployment tutorials and
+it works against either `podman` or `docker`. See {any}`podman-compose` for how
+to use `docker compose` with `podman`; with `docker`, `docker compose` is built
+in and needs no extra configuration.
+:::
 
-There are a few things to know if you are using `docker` in your developer containers:
+## Installing Docker
 
-1. add `export EC_REMOTE_USER=$USER` into your `$HOME/.bashrc` (or `$HOME/.zshrc` for zsh users). The epics-containers devcontainer.json files will use this to set the account that your user will use inside devcontainers.
-1. you may need to tell git that you are ok with the repository permissions. `vscode` may ask you about this or you may need to do the command:
+Install the free Linux CLI tools from <https://docs.docker.com/engine/install/>.
+
+The docker install page encourages you to install Docker Desktop. This is a paid
+for product and is not required for these tutorials. You can install the free
+Linux CLI tools by clicking on the appropriate Linux distribution link under the
+"Supported Platforms" heading; for simplicity it is easiest to use the option
+"Install using the convenience script".
+
+epics-containers has been tested with docker 24.0.5 and higher. Any version of
+docker since 20.10 will work.
+
+## Rootless vs Rootful Docker
+
+The main difference between `podman` and `docker` is that `podman` is rootless by
+default while `docker` is rootful by default. See {any}`rootless` for an
+explanation of why rootless operation is preferred for developing and running
+IOCs.
+
+The good news is that `docker` also supports a rootless mode. **We recommend
+running docker in rootless mode** because it then behaves almost identically to
+`podman` and none of the extra steps in the {ref}`rootful-docker` section below
+are required.
+
+### Recommended: Rootless Docker
+
+In rootless mode docker is, for our purposes, equivalent to podman and you can
+follow the rest of the documentation without any of the extra steps below.
+
+To switch an existing docker install to rootless mode see the description of
+`dockerd-rootless-setuptool.sh` in
+[the docker rootless instructions](https://docs.docker.com/engine/security/rootless/#install).
+
+The following worked on Ubuntu 24.04 with a default docker install at version
+27.2.0. Your mileage may vary on other distributions.
+
+1. The docker install comes with a script to set up rootless operation. We use
+   `--force` to tell it to run even though rootful is already set up.
+
+    ```bash
+    dockerd-rootless-setuptool.sh --force
+    ```
+
+1. The script may report errors and explain how to get around them. In one case
+   it asked for the `uidmap` package to be installed:
+
+    ```bash
+    sudo apt-get install -y uidmap
+    ```
+
+1. You can switch between rootless and rootful operation by changing the
+   `DOCKER_HOST` environment variable.
+
+   To use rootless docker:
+
+    ```bash
+    export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
+    docker ps -a
+    ```
+
+   To switch back to rootful docker:
+
+    ```bash
+    export DOCKER_HOST=unix:///var/run/docker.sock
+    docker ps -a
+    ```
+
+   (Make sure the rootful service is still running if you intend to switch back
+   to it: `sudo systemctl enable --now docker.service docker.socket`.)
+
+(rootful-docker)=
+### Using Rootful Docker
+
+If you cannot or do not want to use rootless docker then you can still use
+rootful docker, but a few extra steps are required. These are needed because a
+rootful docker container runs as the `root` user on the host, so any host files
+written by the container are owned by `root`.
+
+The differences when using rootful docker are:
+
+- **It is best not to run containers as root.** Tell developer containers to run
+  as your own user id by adding the following to your `$HOME/.bashrc` (or
+  `$HOME/.zshrc` for zsh users):
+
+    ```bash
+    export EC_REMOTE_USER=$USER
+    ```
+
+  The epics-containers `devcontainer.json` files use this to set the account
+  that you will use inside developer containers. If you do not set this, your
+  developer container will run as root and all files written to your host
+  workspace will be owned by root.
+
+- **UIDGID** must be passed to the compose file so that the phoebus container
+  runs as the correct user. The `environment.sh` files set `UIDGID` to
+  `USERID:GROUPID` for docker (it is `0:0` for podman, which needs no special
+  handling).
+
+- **Git repository permissions.** `vscode` may ask you to mark the repository as
+  safe, or you may need to run:
+
     ```bash
     git config --global --add safe.directory <Git folder>
     ```
-1. you can use `sudo` if you are having permissions issues. In particular the following will reset permissions on all of the epics files inside the container filesystem:
+
+- **Fixing file ownership.** If you hit permissions issues you can use `sudo`
+  inside the container. For example, the following resets ownership on all of
+  the EPICS files inside the container filesystem:
+
     ```bash
-    sudo chown -r vscode /epics
+    sudo chown -R vscode /epics
     ```
+
+We do fully support rootful `docker`, please report any issues you find.
+
+## Troubleshooting Docker
+
+### Cannot connect to the Docker daemon
+
+Solution 1: start the daemon manually with `systemctl start docker`. If the
+daemon was already running, add your user to the `docker` group, then log out
+and in for the change to be effective.
+
+Solution 2: use rootless docker as described above; the way to set this up
+depends on your distribution and in some cases is a matter of installing a
+variant package like `docker-rootless`.
+
+### Docker daemon errors initializing graphdriver
+
+Solution: the most likely reason is that you are using a filesystem like `zfs`
+or `btrfs` which requires a special storage driver, click
+[link](https://docs.docker.com/engine/storage/drivers/select-storage-driver/)
+for more information.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -48,7 +48,7 @@ be adjusted to suit your domain. The variables are as follows:
   need to create a namespace for your domain. This is the name you should
   use here. If you are not using Kubernetes then you can leave this as
   `EC_K8S_NAMESPACE=local` and this will deploy IOC Instances to the local server's
-  docker or podman instance.
+  podman instance.
 
 - **EC_SERVICES_REPO**: this is a link back to the repository that defines this
   domain. For example the bl38p reference beamline repository uses
@@ -67,12 +67,12 @@ be adjusted to suit your domain. The variables are as follows:
     `=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A`
     `{ioc_name}*'`
 
-- **EC_CONTAINER_CLI**: this sets the name of the container CLI to use. supported
-  options are `podman` or `docker`. If not set then `ec` will try to
-  determine which one to use. You would only need this variable if you have
-  both podman and docker installed and you want to use one over the other, or
-  if you want to use a different container CLI such as `singularity`.
-  IMPORTANT: the application you reference must have docker compatible CLI
+- **EC_CONTAINER_CLI**: this sets the name of the container CLI to use. This
+  defaults to `podman`. If not set then `ec` will try to determine which one to
+  use. You would only need this variable if you have more than one container CLI
+  installed and you want to select a specific one (for example to use `docker` -
+  see {any}`using-docker` - or a different CLI such as `singularity`).
+  IMPORTANT: the application you reference must have a docker compatible CLI
   (at least for common functions).
 
 - **EC_DEBUG**: causes the `ec` command to output debug information for all

--- a/docs/reference/services_config.md
+++ b/docs/reference/services_config.md
@@ -75,7 +75,7 @@ TODO - these following sections are WORK IN PROGRESS.
 
 ## Environment Setup
 
-Every services repository has an `environment.sh` file used to configure your shell so that the command line tools know which cluster to talk to. Up to this point we have been using the local docker or podman instance, but here we have configured it to use the the cluster. The copier template should have created the correct settings in **environment.sh** for you. But you can review them by if needed here {any}`../reference/environment`.
+Every services repository has an `environment.sh` file used to configure your shell so that the command line tools know which cluster to talk to. Up to this point we have been using the local podman instance, but here we have configured it to use the the cluster. The copier template should have created the correct settings in **environment.sh** for you. But you can review them by if needed here {any}`../reference/environment`.
 
 TODO pull the above ref into this page and update it.
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -53,8 +53,6 @@ Very occasionally it may be necessary to reset all of your container cache. You 
 To remove all container cache on a workstation:
 
 ```bash
-# clean out the docker local cache
-docker system prune -af
 # clean out the podman local cache
 podman system reset -f
 ```
@@ -71,14 +69,14 @@ If on the other hand you would like to just clear individual containers or image
 
 ```bash
 # list all containers including stopped ones
-docker ps -a
+podman ps -a
 # use the generated name (last column) to remove some containers
-docker rm container_name1 container_name2
+podman rm container_name1 container_name2
 
 # list all images
-docker images
+podman images
 # use the image id to remove some images
-docker rmi image_id1 image_id2
+podman rmi image_id1 image_id2
 ```
 
 ## Permissions issues with GitHub
@@ -101,17 +99,21 @@ ssh-add ~/.ssh/id_rsa
 Where `id_rsa` is the name of your private key file you use for connecting
 to GitHub.
 
-## Cannot connect to the Docker daemon
+## Cannot connect to the container service
 
-Solution 1: start the daemon manually with `systemctl start docker`,
-if the daemon was already running, add your user to the `docker` group, then
-log out and in for the change to be effective.
+`podman` is daemonless, but `docker compose` talks to it through the podman
+socket. If compose cannot connect, make sure the podman user socket is running
+and that `DOCKER_HOST` points at it:
 
-Solution 2: use rootless docker, the way to setup this depends on your
-distribution, in some cases, it's a matter of installing a variant package
-like `docker-rootless`.
+```bash
+systemctl enable --user podman.socket --now
+export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+```
 
-## Docker daemon errors initializing graphdriver
+(If you are using docker instead of podman, see {any}`using-docker` for docker
+daemon troubleshooting.)
+
+## Container storage errors initializing the storage driver
 
 Solution: The most likely reason is that you are using a filesystem like `zfs`
 or `btrfs` which requires a special storage driver, click

--- a/docs/tutorials/create_ioc.md
+++ b/docs/tutorials/create_ioc.md
@@ -428,8 +428,8 @@ database then you can copy these two files out of the container and into
 your IOC Instance config folder like this:
 
 ```bash
-docker cp t01-services-bl01t-ea-cam-01-1:/epics/runtime/st.cmd services/bl01t-ea-cam-01/config
-docker cp t01-services-bl01t-ea-cam-01-1:/epics/runtime/ioc.subst services/bl01t-ea-cam-01/config/ioc.subst
+podman cp t01-services-bl01t-ea-cam-01-1:/epics/runtime/st.cmd services/bl01t-ea-cam-01/config
+podman cp t01-services-bl01t-ea-cam-01-1:/epics/runtime/ioc.subst services/bl01t-ea-cam-01/config/ioc.subst
 # no longer need an ibek ioc yaml file
 rm services/bl01t-ea-cam-01/config/ioc.yaml
 ```

--- a/docs/tutorials/debug_generic_ioc.md
+++ b/docs/tutorials/debug_generic_ioc.md
@@ -39,8 +39,6 @@ This removes installation of the system dependency on the `libpcre3-dev` package
 Now rebuild the container - do this command from a new terminal *outside* of the devcontainer:
 
 ```bash
-# for docker users - builkit complicates debugging at present
-export DOCKER_BUILDKIT=0
 cd ioc-lakeshore340 # where you cloned it
 ./build
 ```
@@ -76,7 +74,7 @@ STEP 18/22: RUN ansible.sh StreamDevice
 ```
 
 - copy the hash of the step you want to debug e.g. `da81452bc214` in this case
-- `docker run -it --entrypoint /bin/bash da81452bc214 # (the hash you copied)`
+- `podman run -it --entrypoint /bin/bash da81452bc214 # (the hash you copied)`
 
 Now we have a prompt inside the part-built container and can retry the failed
 command.
@@ -108,7 +106,7 @@ Whether inside the container or in your workstation terminal, install
 `apt-file` like this:
 
 ```bash
-# drop the sudo from the start of the command if using podman
+# inside a podman container you are root, so you can omit the sudo
 sudo apt update
 sudo apt install apt-file
 ```

--- a/docs/tutorials/deploy_example.md
+++ b/docs/tutorials/deploy_example.md
@@ -4,7 +4,7 @@
 
 This tutorial will show you how to deploy and manage the example IOC Instance `example-test-01` that came with the template beamline repository. You will need to have your own `t01-services` beamline repository from the previous tutorial.
 
-For these early tutorials we are not using Kubernetes and instead are deploying IOCs to the local docker or podman instance. These kind of deployments are ideal for testing and development on a developer workstation. They could also potentially be used for production deployments to beamline servers where Kubernetes is not available.
+For these early tutorials we are not using Kubernetes and instead are deploying IOCs to the local podman instance. These kind of deployments are ideal for testing and development on a developer workstation. They could also potentially be used for production deployments to beamline servers where Kubernetes is not available.
 
 ## Continuous Integration
 
@@ -49,7 +49,7 @@ source ./environment.sh
 
 The environment file is the same for all local deployment services projects and sets up the following. The defaults supplied are all intended for developer workstation use:
 - sets permissions on **xhost** to allow local containers to display GUIs on the host.
-- sets **UIDGID** which is used to set which account and group the phoebus container is launched with. This is always 0:0 for podman and USERID:GROUPID for docker. Only required for developer workstations.
+- sets **UIDGID** which is used to set which account and group the phoebus container is launched with. This is always 0:0 for podman. Only required for developer workstations.
 - sets **COMPOSE_PROFILES** which determines which compose profile is launched. Defaults to the 'test' profile intended for testing on developer workstations. It runs a ca-gateway container that publishes PVs on localhost and a container for phoebus to provide an OPI.
 - sets **EPICS_CA_ADDR_LIST** to localhost so that host can see the containerised IOC PVs on a developer workstation.
 
@@ -133,7 +133,7 @@ Once you have a shell inside the container you could inspect the following folde
 
 Being at a terminal prompt inside the IOC container can be useful for debugging and testing. You will have access EPICS command line tools including pvAccess, and you can inspect files such as the IOC startup script.
 
-In the Virtual Machine supplied for testing epics-containers we do not install EPICS into the host environment. Instead you can use an IOC container when you need EPICS tools. Working this way makes your developer environment very portable, you only require docker or podman to work on any IOC project. It is equally possible to install EPICS on your host and use the host tools to interact with the IOC container, for the developer configuration you would just need to make sure `EPICS_CA_ADDR_LIST=127.0.0.1`.
+In the Virtual Machine supplied for testing epics-containers we do not install EPICS into the host environment. Instead you can use an IOC container when you need EPICS tools. Working this way makes your developer environment very portable, you only require podman to work on any IOC project. It is equally possible to install EPICS on your host and use the host tools to interact with the IOC container, for the developer configuration you would just need to make sure `EPICS_CA_ADDR_LIST=127.0.0.1`.
 
 ### Logging
 
@@ -184,4 +184,4 @@ dbl
 # ctrl-p ctrl-q to detach
 ```
 
-Use the command sequence ctrl-P then ctrl-Q to detach from the IOC. **However, there are issues with both VSCode and IOC shells capturing ctrl-P**. Until this is resolved it may be necessary to close the terminal window to detach. You can also restart and detach from the IOC using ctrl-D or ctrl-C, or by typing `exit`. If you do this docker will restart your IOC right away.
+Use the command sequence ctrl-P then ctrl-Q to detach from the IOC. **However, there are issues with both VSCode and IOC shells capturing ctrl-P**. Until this is resolved it may be necessary to close the terminal window to detach. You can also restart and detach from the IOC using ctrl-D or ctrl-C, or by typing `exit`. If you do this podman will restart your IOC right away.

--- a/docs/tutorials/dev_container.md
+++ b/docs/tutorials/dev_container.md
@@ -118,7 +118,7 @@ docker compose down
 One issue with compose is that you must have the project available to use compose commands. If you have removed t01-services then you can stop all the services manually instead. To stop and remove all containers on your workstation use the following command:
 
 ```bash
-docker stop $(docker ps -q)
+podman stop $(podman ps -q)
 ```
 :::
 
@@ -137,25 +137,13 @@ Make sure you use the `--recursive` flag to fetch the `ibek-support` submodule. 
 
 If you forget to use the `--recursive` flag you can fetch the submodule with `git submodule update --init`.
 
-:::{important}
-Users of docker need to instruct the devcontainer to use their own user id inside the container. You can do this with the following command:
-
-```bash
-export EC_REMOTE_USER=$USER
-```
-
-It is recommended that you place this command in `$HOME/.bashrc` (or `$HOME/.zshrc` for zsh users) to make it permanent.
-
-If you do not do this, your devcontainer will run as root. This will cause problems as all files written on your host workspace will be owned by root.
-:::
-
 ### Launching the Developer Container
 
 In this section we are going to use vscode to launch a developer container. This means that all vscode terminals and editors will be running inside our container and browsing for files within the container filesystem. This is a very convenient way to work because:
 - the development environment is saved alongside the source code
 - you can easily share the development environment with other developers
 - your development environment is portable between machines
-- development has no dependencies on the host machine except for docker/podman
+- development has no dependencies on the host machine except for podman
 
 For epics-containers, the generic IOC *is* the developer container. When you build the developer target of the container in CI, it will contain all the build tools and dependencies needed to build the IOC. It will also contain the IOC source code and the support module source code. For this reason, we can also use the same developer target image to make the developer container itself. We then have an environment that encompasses all the source you could want to change inside of a Generic IOC, and the tools to build and test it.
 

--- a/docs/tutorials/dev_container2.md
+++ b/docs/tutorials/dev_container2.md
@@ -37,7 +37,7 @@ caget -#100 BL01T-EA-CAM-01:ARR:ArrayData
 
 This just shows that you have all the EPICS tools available to you inside the container.
 
-Note that you have the ability to install any other tools you might need inside the container using `sudo apt update; sudo apt install  package-name`, the container is based on **ubuntu 22.04 LTS** (at time of writing) so all packages available for that distro are available to you. podman users should drop the `sudo` from the start of the commands because podman is already running as root inside the container.
+Note that you have the ability to install any other tools you might need inside the container using `apt update; apt install package-name` (no `sudo` is needed because podman makes you root inside the container). The container is based on **ubuntu 22.04 LTS** (at time of writing) so all packages available for that distro are available to you.
 
 
 ## Auto Port Forwarding

--- a/docs/tutorials/intro.md
+++ b/docs/tutorials/intro.md
@@ -12,9 +12,8 @@ some background in the following topics.
 ```{eval-rst}
 ================================================================    ================
 **An introduction to containers**                                   https://www.docker.com/resources/what-container/
-**Managing containers on a workstation: introduction to docker**    https://docs.docker.com/get-started/overview/
+**Managing containers on a workstation: introduction to podman**    https://docs.podman.io/en/latest/Introduction.html
 **Introduction to docker compose**                                  https://docs.docker.com/compose/
-**Podman, a recommended docker alternative**                        https://docs.podman.io/en/latest/Introduction.html
 **Orchestrating containers in a cluster with Kubernetes**           https://kubernetes.io/docs/concepts/overview/
 **Managing packages in a Kubernetes Cluster with Helm**             https://helm.sh/docs/intro/quickstart/
 **Introduction to EPICS**                                           https://docs.epics-controls.org/en/latest/guides/EPICS_Intro.html

--- a/docs/tutorials/setup_k8s_new_beamline.md
+++ b/docs/tutorials/setup_k8s_new_beamline.md
@@ -2,7 +2,7 @@
 
 # Create a New Kubernetes Beamline
 
-Up until now the tutorials have been deploying IOCs to the local docker or podman instance on your workstation using compose. In this tutorial we look into creating a beamline repository that deploy's into a Kubernetes cluster.
+Up until now the tutorials have been deploying IOCs to the local podman instance on your workstation using compose. In this tutorial we look into creating a beamline repository that deploy's into a Kubernetes cluster.
 
 Helm is a package manager for Kubernetes that allows you to define a set of resources that make up your application in a **Chart**. This is the most popular way to deploy applications to Kubernetes.
 

--- a/docs/tutorials/setup_workstation.md
+++ b/docs/tutorials/setup_workstation.md
@@ -5,7 +5,7 @@ in readiness for the remaining tutorials.
 The tools you need to install are:
 
 - Visual Studio Code
-- a container platform, either docker or podman and docker-compose
+- a container platform: podman (plus docker-compose)
 - Python 3.10 or later + a Python virtual environment
 - git client for version control (Configured for the current user, with read-write access for Repository Contents and Workflows.)
 
@@ -74,13 +74,13 @@ This VM has the following software pre-installed:
 - Ubuntu 22.04
 - Python 3.10
 - Visual Studio Code
-- Docker
+- Podman
 - zsh shell with oh-my-zsh
 
 You will need to complete the following steps to personalize the VM:
 - Set up your github credentials
 - Set up your python virtual environment
-- Set up your docker or podman CLI completion if you want it
+- Set up your podman CLI completion if you want it
 
 Now jump to {ref}`cli-completion` below.
 
@@ -111,7 +111,7 @@ on how to do this.
 - Recommended: [VSCode EPICS]
 - Recommended: [Kubernetes]
 
-### Setup Docker or Podman
+### Setup Podman
 
 :::{Note}
 **DLS Users**: RHEL 8 Workstations at DLS have podman 4.9.4 installed by default. RHEL 7 Workstations are not supported.
@@ -126,26 +126,29 @@ sed -i ~/.config/containers/containers.conf -e '/label=false/d' -e '/^\[containe
 ```
 :::
 
-Next install docker or podman as your container platform. epics-containers
-has been tested with podman 4.4.1 and higher on RedHat 8, and Docker 24.0.5 and higher on for Ubuntu 22.04 and higher.
+We recommend `podman` as your container platform. epics-containers works best
+with `podman` because it is rootless by default, which is simpler and more
+secure for developing and running IOCs (see {any}`rootless` for the details).
+epics-containers has been tested with podman 4.4.1 and higher on RedHat 8 and
+Ubuntu 22.04 and higher. The podman version required is 4.0 or later.
 
-The podman version required is 4.0 or later. Any version of docker since 20.10 will also work.
+The link below has details of how to install podman:
 
-Because we use docker compose which is built in to later versions of docker, we recommend using docker if you have a choice.
-
-The links below have details of how to install your choice of container platform:
-
-- [Install docker]
 - [Install podman]
 
-The docker install page encourages you to install Docker Desktop. This is a paid for product and is not required for this tutorial. You can install the free linux CLI tools by clicking on the appropriate linux distribution link under the "Supported Platforms" heading, for simplicity it is easiest to use the option "Install using the convenience script".
+:::{note}
+**Prefer to use docker?** epics-containers fully supports `docker` as well. The
+rest of this documentation refers to `podman` throughout, so if you would rather
+use `docker` see {any}`using-docker` for how to install it and the few
+extra steps it requires. Everything else in the tutorials works the same way.
+:::
 
 (podman-compose)=
 ### Docker Compose For Podman Users
 
 docker compose allows you to define and run multi-container Docker applications. epics-containers uses it for describing a set of IOCs and other services that are deployed together. It is a useful starting point for tutorials before moving on to Kubernetes. It could also form the basis of a production deployment for those not using Kubernetes.
 
-If you installed docker using the above instructions then docker compose is already installed. If you installed podman then you will need to install docker compose separately. We prefer to use docker-compose instead of podman-compose because it is more widely used and there are still some issues with podman-compose at the time of writing.
+Since you installed podman you will need to install docker compose separately (the steps below show how). We prefer to use docker-compose instead of podman-compose because it is more widely used and there are still some issues with podman-compose at the time of writing.
 
 :::{Note}
 **DLS Users**: docker compose integration with podman is available on RHEL 8 Workstations at DLS. Run `module load docker-compose` to enable it.
@@ -177,34 +180,29 @@ Steps to combine podman and docker-compose:-
     sudo pacman -R podman-compose
     ```
 
-### Important Notes Regarding docker and podman
+### Using docker instead of podman
 
-From here on when we refer to `docker` in a command line, you can replace it with `podman` if you are using podman. The two tools have (almost) the same CLI. For convenience if you are a podman user you might want to place
-```bash
-alias docker=podman
-```
-in your `$HOME/.bashrc` (or `$HOME/.zshrc` for zsh users).
-
-`docker` users should also take a look at this page: [](../reference/docker.md) which describes a couple of extra steps that are required to make docker work in developer containers.
+From here on the tutorials always refer to `podman` on the command line. If you
+have chosen to use `docker` instead, the two tools have (almost) the same CLI so
+every `podman` command has an identical `docker` equivalent. See
+[](../reference/docker.md) for how to install docker, how to run it rootless
+(recommended) and the couple of extra steps that rootful docker requires to work
+in developer containers.
 
 (cli-completion)=
 ### Command Line Completion
 
-This is an optional step to set up CLI completion for docker or podman.
+This is an optional step to set up CLI completion for podman.
 
-It is much easier to investigate the commands available to you with command line completion enabled. You need only do the following steps once to permanently enable this feature for docker and docker compose.
+It is much easier to investigate the commands available to you with command line completion enabled. You need only do the following steps once to permanently enable this feature for podman.
 
 ```bash
 # these steps will make cli completion work for bash
 mkdir -p ~/.local/share/bash-completion/completions
-docker completion bash > ~/.local/share/bash-completion/completions/docker
-# OR
 podman completion bash > ~/.local/share/bash-completion/completions/podman
 
 # these steps will make cli completion work for zsh
 mkdir -p ~/.oh-my-zsh/completions
-docker completion zsh > ~/.oh-my-zsh/completions/_docker
-# OR
 podman completion zsh > ~/.oh-my-zsh/completions/_podman
 ```
 
@@ -274,13 +272,12 @@ You don't need Kubernetes yet.
 
 The following tutorials will take you through creating, deploying and debugging IOC instances, generic IOCs and support modules.
 
-For simplicity we don't encourage using Kubernetes at this stage. Instead we will deploy containers to the local workstation's docker or podman instance using docker compose.
+For simplicity we don't encourage using Kubernetes at this stage. Instead we will deploy containers to the local workstation's podman instance using docker compose.
 
 If you are planning not to use Kubernetes at all then now might be a good time to install an alternative container management platform such as [Portainer](https://www.portainer.io/). Such tools will help you visualise and manage your containers across a number of servers. These are not required and you could just manage everything from the docker compose command line if you prefer.
 
 [download visual studio code]: https://code.visualstudio.com/download
 [how to use wsl2 and visual studio code]: https://code.visualstudio.com/blogs/2019/09/03/wsl2
-[install docker]: https://docs.docker.com/engine/install/
 [install podman]: https://podman.io/getting-started/installation
 [kubernetes]: https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools
 [remote development]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack


### PR DESCRIPTION
Switch the documentation to recommend `podman` as the container engine and refer to `podman` everywhere. All discussion of `docker` is consolidated onto a single page — `docs/reference/docker.md` — which is linked only from the workstation install page. We continue to use `docker compose`/`docker-compose` with podman, so those references are left as-is (as are `Dockerfile`, `DockerHub`, `Docker Swarm` and registry/URL names).

## Anchor pages
- **`reference/docker.md`** — rewritten as the single "Using Docker Instead of Podman" page. Recommends running docker **rootless** (behaves like podman), documents the extra steps **rootful** docker needs (`EC_REMOTE_USER`, `UIDGID`, git `safe.directory`, `sudo chown`), and absorbs the docker-daemon troubleshooting + rootless-setup instructions.
- **`tutorials/setup_workstation.md`** — recommends podman; install/CLI-completion steps are podman-only; holds the single pointer to the docker page.
- **`explanations/rootless.md`** — now a conceptual explanation of why rootless (hence podman) is recommended; docker-specific config moved to the docker page.

## Everywhere else
Prose like "the local docker or podman instance" → "the local podman instance", and standalone engine commands (`docker run/ps/cp/stop/rm/images/system …`) → `podman …`. The docker-only `EC_REMOTE_USER` devcontainer note and the `DOCKER_BUILDKIT=0` note were removed (not needed for podman; covered on the docker page).

18 files changed. Added cross-reference labels (`using-docker`, `rootless`, `rootful-docker`); the `sphinx-build --fail-on-warning` build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized local development, setup, and workflow guides to consistently use Podman commands/terminology.
  * Updated tutorials, debugging, troubleshooting, and environment variable references to reflect Podman usage (including container inspection/cleanup and IOC copy commands).
  * Reworked the Docker documentation into a dedicated “Docker instead of Podman” guide, including installation and rootless/rootful troubleshooting.
  * Refined container-runtime explanations (e.g., rootless recommendations and Podman-focused network notes).
* **Configuration**
  * Updated the development container configuration to explicitly grant access to `/dev/net/tun`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->