### PR TITLE
Remove unresolved copier merge conflict markers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,8 @@ Quick Start
 See [Essential Concepts](https://epics-containers.github.io/main/explanations/introduction.html)
 and the [Getting Started Guide](https://epics-containers.github.io/main/tutorials/intro.html)
 
-<<<<<<< before updating
 Useful Links
 ============
-=======
-What            | Where
-:---:           | :---:
-Source          | <https://github.com/epics-containers/epics-containers>
-Documentation   | <https://epics-containers.github.io/epics-containers>
-Releases        | <https://github.com/epics-containers/epics-containers/releases>
->>>>>>> after updating
 
 | Item           | Link
 | -------------- | ---------------------


### PR DESCRIPTION
## Problem

`main`'s `README.md` contains unresolved git/copier merge conflict markers:

```
<<<<<<< before updating
Useful Links
============
=======
What            | Where
...
>>>>>>> after updating
```

These were introduced by the python-copier-template **v5.0.3** update (#227), which merged into `main` with the conflict left unresolved. The subsequent promote-podman merge (#229) landed on top without touching the README, so the markers remain on `main`.

## Fix

Resolve the conflict the way the rest of the repo already expects: keep the existing **Useful Links** heading and the org-specific `| Item | Link |` table, and drop the copier template's generic placeholder table (which pointed at a non-existent generic `epics-containers/epics-containers` repo).

## Verification

- `git grep` across the whole tree confirms `README.md` was the **only** file on `main` carrying conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`, `before updating`, `after updating`).
- Resulting README matches the clean version already present on the merged `promote-podman` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the README’s “Useful Links” section heading and cleaned up leftover merge-conflict formatting.
  * Restored consistent heading styling without changing any functional content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->