### PR TITLE
Use uv instead of a python venv to install the CLI tools

### DIFF
--- a/docs/explanations/changes.md
+++ b/docs/explanations/changes.md
@@ -42,7 +42,7 @@ All `ec` SemVer components will always have their major version bumped simultane
 Updating user projects
 ----------------------
 
-A repository that was originally created using a copier template can be updated to a new version using the following command (assumes you have an active python venv with copier installed):
+A repository that was originally created using a copier template can be updated to a new version using the following command (assumes you have `copier` installed, e.g. with `uv tool install copier`):
 
 ```bash
 copier update -r VERSION_NUMBER --trust .

--- a/docs/how-to/copier_update.md
+++ b/docs/how-to/copier_update.md
@@ -10,13 +10,15 @@ Below are some details on how to use this tool.
 Introduction
 ------------
 
-copier is a python package. To make use of it you require an activated python virtual environment with copier installed. If you don't already have one of these then the following commands will set one up for you:
+copier is a python command line tool. We recommend installing it with [uv](https://docs.astral.sh/uv/), which puts `copier` on your `PATH` without needing a virtual environment:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install copier
+uv tool install copier
 ```
+
+:::{Note}
+**DLS Users**: you can obtain `uv` with `module load uv`.
+:::
 
 NOTE: generic IOCs with a given major version number template should work with beamline repos with the same major version number template. When updating a beamline repo to a new major version, you may also need to update the generic IOCs it references. If this is the case it will be noted in [](../reference/changelog.md). Having said this, the two types of repo are reasonably well decoupled and we would aim to avoid this necessity. In which case update the beamline repo first and then the generic IOCs as and when new features are required.
 

--- a/docs/how-to/ibek-support.md
+++ b/docs/how-to/ibek-support.md
@@ -18,8 +18,8 @@ git clone git@github.com:epics-containers/ibek-defs.git
 # clone an example domain repo with example IOC yaml
 git clone git@gitlab.diamond.ac.uk:controls/containers/accelerator/acc-psc.git
 
-# get latest ibek installed
-pip install ibek
+# get latest ibek installed (DLS users: module load uv)
+uv tool install ibek
 
 cd acc-psc/services/sr25a-ioc-01
 ibek build-startup config/ioc.boot.yaml ../../../ibek-defs/*/*.yaml

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -86,10 +86,10 @@ The second section of the `environment.sh` file is used to install the
 it would probably be best to have `ec` installed globally on your
 workstation and then omit this section from your `environment.sh` files.
 
-Perhaps the simplest way to achieve this is to install `ec` into your user space using the following command:
+Perhaps the simplest way to achieve this is to install `ec` as a `uv` tool (DLS users can obtain `uv` with `module load uv`):
 
 ```bash
-pip install --user ec-cli
+uv tool install edge-containers-cli
 ```
 
 Then add the following to your `$HOME/.bashrc` (or `$HOME/.zshrc` for zsh users):

--- a/docs/tutorials/create_beamline.md
+++ b/docs/tutorials/create_beamline.md
@@ -42,7 +42,7 @@ NOTE: for these tutorials we will use your personal GitHub Account to store ever
 
 ## Steps
 
-1. Make sure you have activated the python virtual environment and that `copier` is installed. See instructions here: {any}`copier`.
+1. Make sure `copier` is installed. See instructions here: {any}`copier`.
 
 1. Use copier to copy the services template repository to a new repository named `t01-services`. Note that there are two services templates, one for local deployments (using docker compose) and one for deployments to Kubernetes. We will use the local deployment template here.
 

--- a/docs/tutorials/generic_ioc.md
+++ b/docs/tutorials/generic_ioc.md
@@ -70,10 +70,9 @@ your personal GitHub user space.
 
 1. Create a new repository in your GitHub account using this link <https://github.com/new>. Give your new repository the name `ioc-lakeshore340` plus a description, then click 'Create repository'.
 
-1. From a command line with your virtual environment activated. Use copier to start to make a new repository like this:
+1. From a command line, use copier to start to make a new repository like this (if you don't have `copier` installed yet see {any}`copier`):
 
       ```bash
-      source $HOME/ec-venv/bin/activate
       # this will create the folder ioc-lakeshore340 in the current directory
       copier copy https://github.com/epics-containers/ioc-template --trust ioc-lakeshore340
       ```

--- a/docs/tutorials/setup_k8s.md
+++ b/docs/tutorials/setup_k8s.md
@@ -111,7 +111,6 @@ This should return the name of your single worker node (i.e. your server or work
 $ kubectl get node
 NAME    STATUS   ROLES                  AGE   VERSION
 ecws1   Ready    control-plane,master   25m   v1.30.4+k3s1
-(venv)
 ```
 
 ### Create an epics IOCs namespace and context

--- a/docs/tutorials/setup_k8s_new_beamline.md
+++ b/docs/tutorials/setup_k8s_new_beamline.md
@@ -23,7 +23,7 @@ As before, we will use a copier template to create the new beamline repository. 
 1. We are going to call the new beamline **bl03t** with the repository name **t03-services**. It will be created in the namespace **t03-beamline** on the local cluster that we created in the last tutorial **OR** your *fedid* namespace on the **Pollux** cluster if you are using the DLS cluster.
 
     ```bash
-    # make sure your Python virtual environment is active and copier is pip installed
+    # make sure copier is installed (see the workstation setup)
     copier copy https://github.com/epics-containers/services-template-helm t03-services
     ```
 
@@ -116,11 +116,11 @@ If you have brought your own cluster then you may need to edit the **environment
 
 ## Setup the epics containers CLI
 
-To deploy and manage IOC istances requires **helm** and **kubectl** command line tools. However we supply a simple wrapper for these tools that saves typing and helps with learning the commands. Go ahead and add the `edge-containers-cli` python package to your virtual environment if it is not already there.
+To deploy and manage IOC istances requires **helm** and **kubectl** command line tools. However we supply a simple wrapper for these tools that saves typing and helps with learning the commands. Go ahead and install the `edge-containers-cli` python package if it is not already there.
 
 ```bash
-# make sure your Python virtual environment is active, then:
-pip install edge-containers-cli
+# install the ec CLI if you don't already have it:
+uv tool install edge-containers-cli
 # setup the environment for ec to know how to talk to the cluster
 # (make sure you are in the t03-services directory)
 source ./environment.sh

--- a/docs/tutorials/setup_workstation.md
+++ b/docs/tutorials/setup_workstation.md
@@ -219,34 +219,47 @@ There are instructions for installing Python on all platforms here:
 <https://docs.python-guide.org/starting/installation/>
 
 
-### Setup virtual environment
+### Install uv
 
-Once you have python, set up a virtual environment for your epics-containers
-work. In the examples we will use `$HOME/ec-venv` as the virtual environment
-but you can choose any folder.
+We use [uv](https://docs.astral.sh/uv/) to install and run the Python command
+line tools used in these tutorials (such as `copier` and `ec`). `uv` installs
+each tool into its own isolated environment and puts it on your `PATH`, so there
+is no virtual environment to create or activate every time you open a shell.
 
 :::{Note}
-**DLS Users**: As `$HOME` is a network drive it has an 8GB limit, consider other locations such as `/dls/science/` or `/scratch/`. Read more [here](https://dev-portal.diamond.ac.uk/guide/developer-environment/how-tos/disk-quota-troubleshooting/)
+**DLS Users**: you can obtain `uv` with `module load uv` instead of installing
+it yourself, in which case you can skip the install command below.
 :::
 
+Install `uv` with its standalone installer:
+
 ```bash
-python3 -m venv $HOME/ec-venv
-source $HOME/ec-venv/bin/activate
-python3 -m pip install --upgrade pip
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Note that each time you open a new shell you will need to activate the virtual environment again. (Or place its bin folder in your path by adding `PATH=$HOME/ec-venv/bin:$PATH` in your `$HOME/.bashrc` (or `$HOME/.zshrc` for zsh users)).
+See the [uv installation docs](https://docs.astral.sh/uv/getting-started/installation/)
+for other installation methods (including Windows). `uv` can also manage Python
+versions for you, so the tools below will work even without the system Python
+installed above.
 
 (copier)=
 
 ### copier
 
-Above we set up a python virtual environment. Now we will install `copier` which is used to copy the templates for the services repositories and generic IOCs. Also you could take this opportunity to install the `ec` tool that we will use later when we get to the Kubernetes tutorials.
+Now we will install `copier` which is used to copy the templates for the
+services repositories and generic IOCs. Also you could take this opportunity to
+install the `ec` tool that we will use later when we get to the Kubernetes
+tutorials.
 
 ```bash
-pip install copier
-pip install edge-containers-cli
+uv tool install copier
+uv tool install edge-containers-cli
 ```
+
+These commands put `copier` and `ec` on your `PATH` in every new shell, so there
+is nothing to activate. To upgrade them later run `uv tool upgrade --all`. If a
+freshly installed tool is not found, run `uv tool update-shell` (or add
+`$HOME/.local/bin` to your `PATH`) and open a new shell.
 
 ### Git
 


### PR DESCRIPTION
## What

Wherever the docs told users to create a python virtual environment (`python3 -m venv` → `source .../activate` → `pip install ...`) to run the project's Python CLI tools (`copier`, `ec`, `ibek`), recommend [uv](https://docs.astral.sh/uv/) instead.

`uv tool install <tool>` installs each tool into its own isolated environment and puts it on the user's `PATH`, so there is no virtual environment to create or re-activate in every new shell.

## Changes

- **`tutorials/setup_workstation.md`** — replaced the *Setup virtual environment* section with an **Install uv** section (standalone installer + link to the uv install docs), and switched the *copier* step to `uv tool install copier` / `uv tool install edge-containers-cli`.
- Added **DLS Users** notes that `uv` can be obtained with **`module load uv`** (in the workstation setup, `copier_update`, `environment`, and `ibek-support`).
- Converted the remaining venv/`pip install` instructions to `uv tool install`: `how-to/copier_update.md`, `explanations/changes.md`, `tutorials/create_beamline.md`, `tutorials/generic_ioc.md`, `tutorials/setup_k8s_new_beamline.md`, `reference/environment.md`, `how-to/ibek-support.md`.
- Removed a stray `(venv)` shell prompt left in a `setup_k8s.md` example output.

## Out of scope (intentionally unchanged)

- ADRs under `explanations/decisions/` (historical record).
- `how-to/builder2ibek.md` — references an existing DLS prebuilt path, not a venv recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and tutorial instructions to use `uv` for installing tools instead of creating and activating a Python virtual environment.
  * Added guidance for installing tools like `copier`, `ibek`, and `ec` with `uv tool install`.
  * Included a DLS note about loading `uv` with `module load uv`.
  * Cleaned up a stray example artifact in the Kubernetes setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->