### PR TITLE
Fix ec env-var reference and document the backend model (Theme 3)

### DIFF
--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -11,12 +11,17 @@ non-DLS clusters.
 :::{note}
 This page documents the environment variables understood by `ec`
 (the [edge-containers-cli](https://epics-containers.github.io/edge-containers-cli/)).
-The `environment.sh` file that sets them differs slightly between project
-types (services-using-compose, services-using-helm, and deployment repos),
-but the variables themselves are the same.
 
-For the full `ec` command reference and a detailed description of each
-backend, see the
+The role of `environment.sh` depends on the project type:
+
+- in **Helm/Kubernetes services repos** and **deployment repos** it sets the
+  `EC_*` variables documented below to point `ec` at your cluster;
+- in **compose-based services repos** it instead sets up your local
+  `docker compose` environment (container engine, `UIDGID`,
+  `COMPOSE_PROFILES`, EPICS name servers) and does **not** configure `ec`.
+
+The variables documented on this page are the `ec` ones. For the full `ec`
+command reference and a detailed description of each backend, see the
 [edge-containers-cli documentation](https://epics-containers.github.io/edge-containers-cli/).
 :::
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -1,5 +1,13 @@
 # The Environment Configuration File
 
+:::{warning}
+**DLS users — live deployments:** you do **not** need to create or source an
+`environment.sh` for production beamline or accelerator deployments. At DLS the
+module system configures `ec` to deploy to the production clusters for you.
+Sourcing `environment.sh` is only required for local/standalone work and for
+non-DLS clusters.
+:::
+
 :::{note}
 This page documents the environment variables understood by `ec`
 (the [edge-containers-cli](https://epics-containers.github.io/edge-containers-cli/)).

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -1,92 +1,99 @@
 # The Environment Configuration File
 
-:::{warning}
-This page is out of date - the environment.sh varies depending on the type of project:
-- services using compose
-- services using helm
-- deployment
+:::{note}
+This page documents the environment variables understood by `ec`
+(the [edge-containers-cli](https://epics-containers.github.io/edge-containers-cli/)).
+The `environment.sh` file that sets them differs slightly between project
+types (services-using-compose, services-using-helm, and deployment repos),
+but the variables themselves are the same.
 
-This page needs to be updated to reflect the different types of environment.sh files.
+For the full `ec` command reference and a detailed description of each
+backend, see the
+[edge-containers-cli documentation](https://epics-containers.github.io/edge-containers-cli/).
 :::
 
 `environment.sh` is a configuration file that is provided in each domain
-(beamline or accelerator) repository. It is used to set up the environment
-such that the `epics-containers-cli` will interact with the correct
-cluster (or local server if you are not using Kubernetes).
+(beamline or accelerator) repository. It is sourced to set up your shell so
+that `ec` interacts with the correct services repository and deployment
+target (a Kubernetes cluster, an ArgoCD instance, or a local demo).
 
-An important part of creating a new domain repository is to edit the
-`environment.sh` so that it suits the domain you are targetting.
+An important part of creating a new domain repository is to edit
+`environment.sh` so that it suits the domain you are targeting.
 
 There are 3 sections to the file as follows:
 
 ## Environment Variables Setup
 
-The first section defines a number of environment variables. These should
-be adjusted to suit your domain. The variables are as follows:
+The first section defines a number of environment variables. These should be
+adjusted to suit your domain. Every variable can also be supplied as a command
+line option (for example `EC_TARGET` ↔ `ec -t/--target`), and you can print
+the values `ec` is currently using with:
 
-### Required Variables
+```bash
+ec env
+```
 
-- **EC_REGISTRY_MAPPING**: defines a mapping between git source repositories and
-  container repositories. This is used to determine where a Generic IOC
-  container image is pushed to (or pulled from). If you are using GitHub then
-  you could use the following value:
+The variables are as follows:
 
-  - `EC_REGISTRY_MAPPING='github.com=ghcr.io'`
+### Commonly set variables
 
-  Which means containers whose source repository is at:
+- **EC_SERVICES_REPO**: a link to the services repository that defines this
+  domain, for example
+  `EC_SERVICES_REPO=https://github.com/epics-containers/example-services`.
+  `ec` uses this to fetch a versioned (git-tagged) copy of an IOC instance's
+  configuration at deploy time. (`ec -r/--repo`.)
 
-  - `GitHub/organisation/my_generic_ioc`
+- **EC_TARGET**: where `ec` deploys to. Its meaning depends on the backend:
 
-  will be pushed to:
+  - for the `K8S` backend it is the Kubernetes **namespace** your IOC
+    instances are deployed to, e.g. `EC_TARGET=t01`;
+  - for the default `ARGOCD` backend it is `app-namespace/root-app` — the
+    namespace that hosts ArgoCD together with the name of the root
+    (app-of-apps) Application, e.g. `EC_TARGET=t01-beamline/root`.
 
-  - `ghcr.io/organisation/my_generic_ioc:VERSION`.
+  (`ec -t/--target`.)
 
-  You can have multiple mappings if needed by separating them with a space.
+- **EC_CLI_BACKEND**: selects which backend `ec` drives. One of `ARGOCD`
+  (the default), `K8S`, or `DEMO`. The set of available commands and options
+  changes per backend — see [](helm). (`ec -b/--backend`.)
 
-- **EC_K8S_NAMESPACE**: defines the namespace in a Kubernetes Cluster that your IOC
-  Instances will be deployed to. When you come to set up a cluster you will
-  need to create a namespace for your domain. This is the name you should
-  use here. If you are not using Kubernetes then you can leave this as
-  `EC_K8S_NAMESPACE=local` and this will deploy IOC Instances to the local server's
-  podman instance.
+### Optional variables
 
-- **EC_SERVICES_REPO**: this is a link back to the repository that defines this
-  domain. For example the bl38p reference beamline repository uses
-  `EC_SERVICES_REPO=git@github.com:epics-containers/bl38p.git`. This variable
-  is used by `ec` to fetch versioned IOC Instance from the repo and deploy
-  time.
-
-### Optional Variables
+- **EC_LOGIN**: an optional command that `ec` runs to authenticate to the
+  cluster/backend before performing an operation. Leave unset if your shell is
+  already authenticated (for example via `KUBECONFIG`, see below).
 
 - **EC_LOG_URL**: if you have a centralized logging service with a web UI then
-  you can set this variable to the URL of the web UI. This will then be
-  displayed when the command `ec log-history <ioc-name>` is run. The
-  IOC name is added to the URL using `{ioc-name}` as a placeholder e.g.
+  you can set this variable to the URL of the web UI. It is displayed by
+  `ec log-history <service>`. The service name is inserted into the URL using
+  the `{service_name}` placeholder, e.g.
 
   - `EC_LOG_URL='https://graylog2.diamond.ac.uk/search?rangetype=relative&fields`
     `=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A`
-    `{ioc_name}*'`
+    `{service_name}*'`
 
-- **EC_CONTAINER_CLI**: this sets the name of the container CLI to use. This
-  defaults to `podman`. If not set then `ec` will try to determine which one to
-  use. You would only need this variable if you have more than one container CLI
-  installed and you want to select a specific one (for example to use `docker` -
-  see {any}`using-docker` - or a different CLI such as `singularity`).
-  IMPORTANT: the application you reference must have a docker compatible CLI
-  (at least for common functions).
+- **EC_LOG_LEVEL**: sets the logging verbosity of `ec` itself. One of `DEBUG`,
+  `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
 
-- **EC_DEBUG**: causes the `ec` command to output debug information for all
-  commands. For more targeted debugging you can use `ec -d ...`.
+- **EC_VERBOSE**: print each external command (git, kubectl, helm, argocd) that
+  `ec` runs. Equivalent to `ec -v/--verbose`.
+
+- **EC_DRYRUN**: print the external commands that `ec` would run without
+  executing them. Equivalent to `ec --dryrun`.
+
+- **EC_DEBUG**: causes `ec` to output debug information (including Python
+  tracebacks) for all commands. For more targeted debugging you can use
+  `ec -d ...`.
 
 ## Installation of `ec`
 
-The second section of the `environment.sh` file is used to install the
-`ec` command by pip installing the `epics-containers-cli` package. The
-`blxxi-template` project comes with a suggested way of doing this, but
-it would probably be best to have `ec` installed globally on your
-workstation and then omit this section from your `environment.sh` files.
+The second section of the `environment.sh` file installs the `ec` command from
+the `edge-containers-cli` package. The recommended approach is to install `ec`
+globally on your workstation (and then omit this section from your
+`environment.sh` files).
 
-Perhaps the simplest way to achieve this is to install `ec` as a `uv` tool (DLS users can obtain `uv` with `module load uv`):
+The simplest way is to install `ec` as a `uv` tool (DLS users can obtain `uv`
+with `module load uv`):
 
 ```bash
 uv tool install edge-containers-cli
@@ -105,21 +112,19 @@ will connect to a namespace on your Kubernetes cluster. This usually involves
 setting the `KUBECONFIG` environment variable to point to a file that contains
 the cluster configuration.
 
-When we set up a cluster in the tutorials we will create a namespace for your
+When we set up a cluster in the tutorials we will create a namespace for you
 and discuss how to update `environment.sh` to connect to it.
 
-If you are connecting to your own facility's cluster then you will need to
-ask your admins for the correct configuration.
+If you are connecting to your own facility's cluster then you will need to ask
+your admins for the correct configuration.
 
-If you are not using Kubernetes then you can leave this section out.
+If you are not deploying to Kubernetes (for example when using the `DEMO`
+backend or a local compose project) then you can leave this section out.
 
 :::{note}
 DLS users: the module system is used to connect us to each beamline/accelerator
-cluster. The example `environment.sh` file in `bl38p` shows how to do this
-see <https://github.com/epics-containers/bl38p/blob/main/environment.sh>
+cluster. The example `environment.sh` file in
+[example-services](https://github.com/epics-containers/example-services/blob/main/environment.sh)
+shows how to do this, including how to set up command line completion for the
+Kubernetes tools `kubectl` and `helm`.
 :::
-
-One other thing that is useful is to set up command line completion for the
-Kubernetes tools `kubectl` and `helm`. See the end of the bl38p
-`environment.sh` file for an example of how to do this at
-<https://github.com/epics-containers/bl38p/blob/main/environment.sh>.

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -1,15 +1,61 @@
 (helm)=
-# Pure Helm Deployments
+# The `ec` Backend Model
 
-At DLS we use helm charts in our services repos to describe our IOC instances. However we use ArgoCD continuous deployment to deploy them. ArgoCD is a Kubernetes native tool that knows how to keep a set of Helm charts in a git repository in sync with a set of Kubernetes resources.
+`ec` (the [edge-containers-cli](https://epics-containers.github.io/edge-containers-cli/))
+is a thin wrapper around the tools that actually deploy and manage your
+services — `git`, `kubectl`, `helm` and `argocd`. The tool it drives is
+selected by a **backend**, set with the `EC_CLI_BACKEND` environment variable
+(or the `ec -b/--backend` option). There are three backends:
 
-You are not required to use ArgoCD, you can use Helm directly if you prefer. This page discusses how to use the command line tool `ec` to deploy and manage IOC instances using Helm directly. `ec` adds some useful version management features to the workflow that to some extent replicates ArgoCD's ability to track versions.
+| Backend  | `EC_CLI_BACKEND` | Deploys via | Typical use |
+|----------|------------------|-------------|-------------|
+| ArgoCD   | `ARGOCD` (default) | A deployment repository reconciled by ArgoCD | Production continuous deployment |
+| Kubernetes | `K8S`           | `helm` directly against a cluster | Pure-Helm clusters with no ArgoCD |
+| Demo     | `DEMO`           | An in-memory simulation | Trying out `ec` / running the tutorials offline |
 
-## TODO this is WIP
-
-If you set the `EC_CLI_BACKEND` environment variable to `K8S` then `ec` will use Helm directly to deploy and manage IOC instances. You can get a feel for the commands available with `ec --help`.
+The available commands and options change per backend: when a command is not
+implemented for the selected backend it is dropped from `ec --help` entirely.
+So the output of `ec --help` reflects whichever backend is currently active.
 
 ```bash
 export EC_CLI_BACKEND=K8S
-ec --help
+ec --help        # shows only the commands the K8S backend implements
 ```
+
+For the authoritative, per-command reference, see the
+[edge-containers-cli documentation](https://epics-containers.github.io/edge-containers-cli/).
+
+## ARGOCD (default)
+
+This is the production continuous-deployment path used at DLS. The services
+repository describes IOC instances as Helm charts, but `ec` does not deploy
+them directly. Instead a companion **deployment repository** records which
+version of each service should be running, and
+[ArgoCD](https://argo-cd.readthedocs.io/) — a Kubernetes-native tool that keeps
+a set of Helm charts in a git repository in sync with the cluster —
+continuously reconciles the cluster to match it.
+
+With this backend `ec deploy <service> <version>` works by committing the
+chosen version into the deployment repository; ArgoCD then rolls it out. Here
+`EC_TARGET` is `app-namespace/root-app` (the namespace hosting ArgoCD plus the
+name of the root app-of-apps Application).
+
+## K8S
+
+You are not required to use ArgoCD; the `K8S` backend uses Helm directly. `ec`
+adds version-management features on top of Helm that to some extent replicate
+ArgoCD's ability to track versions, but without the git-driven audit trail.
+
+With this backend `EC_TARGET` is simply the Kubernetes **namespace** to deploy
+into. `ec deploy <service> [version]` shallow-clones `EC_SERVICES_REPO` at the
+requested git tag and runs `helm upgrade --install` on the service's chart;
+`ec template` and `ec deploy-local` operate on a local chart instead. Lifecycle
+commands map onto cluster operations — start/stop scale the StatefulSet,
+`ec delete` runs `helm delete`, and `ec logs`/`ec exec`/`ec attach` use
+`kubectl`.
+
+## DEMO
+
+The `DEMO` backend simulates a cluster in memory so you can explore the `ec`
+command set without any infrastructure. It is used by the introductory
+tutorials and for experimenting offline.

--- a/docs/reference/services_config.md
+++ b/docs/reference/services_config.md
@@ -1,6 +1,14 @@
 # Configuring a Services Repository for a Cluster
 
 :::{warning}
+**DLS users — live deployments:** you do **not** need to create or source an
+`environment.sh` for production beamline or accelerator deployments. At DLS the
+module system configures `ec` to deploy to the production clusters for you.
+Sourcing `environment.sh` is only required for local/standalone work and for
+non-DLS clusters. See {any}`environment` for details.
+:::
+
+:::{warning}
 This page is a work in progress.
 :::
 

--- a/docs/tutorials/deploy_example.md
+++ b/docs/tutorials/deploy_example.md
@@ -1,11 +1,11 @@
 # Deploying and Managing IOC Instances
 
-:::{warning}
-**DLS users — live deployments:** you do **not** need to create or source an
-`environment.sh` for production beamline or accelerator deployments. At DLS the
-module system configures `ec` to deploy to the production clusters for you.
-Sourcing `environment.sh` is only required for local/standalone work and for
-non-DLS clusters. See {any}`../reference/environment` for details.
+:::{note}
+On this page `environment.sh` sets up your local `docker compose` environment
+(container engine, `UIDGID`, `COMPOSE_PROFILES`, EPICS name servers) — it does
+**not** configure `ec`, and you do need to source it. See
+{any}`../reference/environment` for the full list of what `environment.sh` can
+set in each kind of repository.
 :::
 
 ## Introduction

--- a/docs/tutorials/deploy_example.md
+++ b/docs/tutorials/deploy_example.md
@@ -1,5 +1,13 @@
 # Deploying and Managing IOC Instances
 
+:::{warning}
+**DLS users — live deployments:** you do **not** need to create or source an
+`environment.sh` for production beamline or accelerator deployments. At DLS the
+module system configures `ec` to deploy to the production clusters for you.
+Sourcing `environment.sh` is only required for local/standalone work and for
+non-DLS clusters. See {any}`../reference/environment` for details.
+:::
+
 ## Introduction
 
 This tutorial will show you how to deploy and manage the example IOC Instance `example-test-01` that came with the template beamline repository. You will need to have your own `t01-services` beamline repository from the previous tutorial.

--- a/docs/tutorials/deploy_example.md
+++ b/docs/tutorials/deploy_example.md
@@ -2,8 +2,7 @@
 
 :::{note}
 On this page `environment.sh` sets up your local `docker compose` environment
-(container engine, `UIDGID`, `COMPOSE_PROFILES`, EPICS name servers) — it does
-**not** configure `ec`, and you do need to source it. See
+(container engine, `UIDGID`, `COMPOSE_PROFILES`, EPICS name servers). See
 {any}`../reference/environment` for the full list of what `environment.sh` can
 set in each kind of repository.
 :::

--- a/docs/tutorials/setup_k8s_new_beamline.md
+++ b/docs/tutorials/setup_k8s_new_beamline.md
@@ -2,6 +2,14 @@
 
 # Create a New Kubernetes Beamline
 
+:::{warning}
+**DLS users — live deployments:** you do **not** need to create or source an
+`environment.sh` for production beamline or accelerator deployments. At DLS the
+module system configures `ec` to deploy to the production clusters for you.
+Sourcing `environment.sh` is only required for local/standalone work and for
+non-DLS clusters. See {any}`../reference/environment` for details.
+:::
+
 Up until now the tutorials have been deploying IOCs to the local podman instance on your workstation using compose. In this tutorial we look into creating a beamline repository that deploy's into a Kubernetes cluster.
 
 Helm is a package manager for Kubernetes that allows you to define a set of resources that make up your application in a **Chart**. This is the most popular way to deploy applications to Kubernetes.

--- a/docs/tutorials/setup_k8s_new_beamline.md
+++ b/docs/tutorials/setup_k8s_new_beamline.md
@@ -3,11 +3,14 @@
 # Create a New Kubernetes Beamline
 
 :::{warning}
-**DLS users — live deployments:** you do **not** need to create or source an
-`environment.sh` for production beamline or accelerator deployments. At DLS the
-module system configures `ec` to deploy to the production clusters for you.
-Sourcing `environment.sh` is only required for local/standalone work and for
-non-DLS clusters. See {any}`../reference/environment` for details.
+**DLS users:** to deploy to DLS infrastructure you should now switch over to our
+internal documentation at
+<https://dev-guide.diamond.ac.uk/epics-containers/>, which covers deploying to
+DLS beamlines and accelerators. Only continue with this tutorial if you want to
+set up your own cluster for learning.
+
+Note also that inside DLS you do **not** need an `environment.sh` — the module
+system configures `ec` for you.
 :::
 
 Up until now the tutorials have been deploying IOCs to the local podman instance on your workstation using compose. In this tutorial we look into creating a beamline repository that deploy's into a Kubernetes cluster.


### PR DESCRIPTION
Addresses **Theme 3** of `DOCS-REVIEW.md`: *"`ec` backend model is undocumented and `reference/environment.md` is wrong."*

## `docs/reference/environment.md`
- Replace the three phantom env vars (`EC_REGISTRY_MAPPING`, `EC_K8S_NAMESPACE`, `EC_CONTAINER_CLI`) with the real set from `edge-containers-cli` (`definitions.py::ENV`): `EC_SERVICES_REPO`, `EC_TARGET`, `EC_CLI_BACKEND`, `EC_LOGIN`, `EC_LOG_URL`, `EC_LOG_LEVEL`, `EC_VERBOSE`, `EC_DRYRUN`, `EC_DEBUG`.
- Fix the package name (`epics-containers-cli` → `edge-containers-cli`).
- Fix the `EC_LOG_URL` placeholder (`{ioc_name}` → `{service_name}`).
- Fix dead `bl38p`/`blxxi-template` links → `example-services`.
- Document `EC_TARGET`'s backend-dependent meaning and add an `ec env` tip.

## `docs/reference/helm.md`
- Replace the `## TODO this is WIP` stub with a proper **backend-model** reference: ARGOCD (default) / K8S / DEMO, per-backend command dropping, and what `EC_TARGET` means in each. The `(helm)=` anchor is preserved so existing cross-references still resolve.
- The K8S specifics (deploy = shallow git clone at tag + `helm package`/`upgrade --install`; start/stop = `kubectl scale statefulset --replicas=1/0`; delete = `helm delete`) were verified against the CLI source.

## Reference-out to the CLI docs
Per the plan, the full per-command `ec` reference is **not** duplicated here — both pages link to the edge-containers-cli documentation at `https://epics-containers.github.io/edge-containers-cli/` (the standard GitHub-Pages convention). That URL 404s until the edge-containers-cli docs are published in a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated environment setup reference to reflect the current `edge-containers-cli` environment variables (commonly set vs optional) and refreshed installation instructions to match the latest tool workflow.
  * Improved guidance on connecting to a Kubernetes namespace, with clearer distinctions for tutorial vs facility-managed setups and added non-Kubernetes clarification.
  * Expanded the Helm reference with a new “Backend Model” section explaining supported backends and how command behavior varies by backend.
  * Added DLS-specific warnings across service and tutorial pages clarifying that production deployments do not require creating or sourcing `environment.sh`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->