### PR TITLE
Docs: add generic ArgoCD deployment explanation + tutorial

### DIFF
--- a/docs/explanations/argocd.md
+++ b/docs/explanations/argocd.md
@@ -1,0 +1,266 @@
+(argocd)=
+
+# How ArgoCD Deploys Your IOCs
+
+epics-containers builds IOCs and other services as Helm charts, but it does
+not push them into your cluster with `helm install`. Instead the production
+deployment path is *GitOps*, driven by [ArgoCD](https://argo-cd.readthedocs.io/).
+This page explains the model: which Git repositories hold what, how a single
+root "app-of-apps" fans out into one ArgoCD `Application` per service, and how
+the `ec` command line tool fits into the picture.
+
+:::{note}
+This is the conceptual companion to the hands-on walk-through in
+{any}`deploy-argocd`. If you want to follow along end to end with the `t01`
+worked example, start there and refer back here for the "why".
+:::
+
+## GitOps in one picture
+
+The central idea of GitOps is that **Git is the single source of truth for the
+desired state of the cluster**, and a controller running *in* the cluster
+continuously reconciles reality to match. With ArgoCD you never run an
+imperative "deploy" command against the cluster. You change a file in Git, and
+ArgoCD notices and makes the cluster agree.
+
+That indirection buys you a lot:
+
+- **The current desired state is discoverable.** One file lists exactly which
+  IOC versions are supposed to be running.
+- **Deploys are consistent.** The same reconciliation runs every time, so there
+  is no "it worked on my machine" drift between operators.
+- **You get a full history for free.** Every change is a Git commit with an
+  author, a timestamp and a message.
+- **Rollback is just `git revert`.** Going back to the state from any past date
+  is reverting a commit; ArgoCD reconciles the cluster back to it.
+
+ArgoCD itself is installed once into your Kubernetes cluster as part of cluster
+setup (see {any}`setup-kubernetes`). Everything below assumes it is already
+running and that the `argocd` CLI is logged in.
+
+## Two repositories, two jobs
+
+The model deliberately splits responsibilities across **two** Git repositories.
+Keeping them separate is the single most important thing to understand.
+
+The **services repository** (the worked example is the public
+<https://github.com/epics-containers/t01-services>) holds the *content* of each
+IOC and service: a Helm chart per service plus its `values.yaml`. This is where
+service definitions are authored and version-tagged, and it is what the earlier
+tutorials build up (see {any}`create-beamline` and {any}`setup-k8s-beamline`).
+See the {any}`services-repo` glossary entry for the full definition.
+
+The **deployment repository** records *which* of those services run, *where*,
+and at *what version*. It is deliberately tiny. You do not clone a ready-made
+one; you scaffold your own (named `t01-deployment` in the worked example) from
+the public `deployment-template-argocd` template. ArgoCD watches this
+repository, not the services repository.
+
+This separation matters because the two repositories change for different
+reasons and at different rates. Service definitions churn as IOCs are developed;
+that activity stays in the services repository and keeps its history clean.
+Deciding to roll `bl01t-ea-fastcs-01` from one tag to the next is an
+*operational* decision, and it lands as a one-line change in the deployment
+repository. The two histories never get tangled.
+
+:::{note}
+ArgoCD is not mandatory. If you would rather drive Helm yourself without a
+GitOps controller, the {any}`helm` page covers the pure-Helm (`EC_CLI_BACKEND=K8S`)
+alternative. The rest of this page describes the ArgoCD path.
+:::
+
+## The root Application (app-of-apps)
+
+ArgoCD's unit of deployment is the `Application` custom resource (an "App"). An
+App points at a Git repository, a path within it, and a target revision, and
+keeps the matching Kubernetes resources in sync.
+
+The deployment repository contains a single root App, defined in `apps.yaml` and
+named for the domain (`t01` in the worked example). Its source path is the
+`apps/` directory **of the deployment repository itself**:
+
+```yaml
+# apps.yaml (the root Application)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: t01                       # named for the domain
+  namespace: t01-beamline
+spec:
+  source:
+    path: apps                    # the apps/ chart in THIS (deployment) repo
+    repoURL: https://github.com/your-org/t01-deployment
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+This is an *app-of-apps*: the one App you bootstrap by hand renders the `apps/`
+chart, which in turn produces all the other Apps. Bootstrapping it is a single
+command (`argocd app create --file apps.yaml`, or the equivalent action in your
+ArgoCD web UI), and from then on the domain manages itself. A freshly scaffolded
+deployment repository seeds a few shared children automatically:
+`t01-epics-pvcs` (shared persistent storage), `t01-epics-opis` (auto-generated
+engineering screens served over HTTP), and, if you enabled gateways,
+`t01-epics-gateways`.
+
+## The control surface: apps/values.yaml
+
+The one file that humans and CI actually edit is `apps/values.yaml`. It is the
+values file for the `apps/` chart, and it declares both the defaults shared by
+every service and the per-service map of what to run:
+
+```yaml
+project: t01-beamline             # ArgoCD project (= the namespace)
+destination:
+  name: your-cluster              # the cluster where the IOCs RUN
+  namespace: t01-beamline
+source:
+  repoURL: https://github.com/epics-containers/t01-services   # the SERVICES repo
+  targetRevision: main            # default branch/tag of the services repo
+services:
+  t01-epics-pvcs:                 # a bare entry inherits all the defaults
+  t01-epics-opis:
+  bl01t-ea-fastcs-01:
+    enabled: true
+  bl01t-di-cam-01:
+    targetRevision: main          # per-service version override
+```
+
+The crucial detail is that `source.repoURL` here points at the **services
+repository**, not the deployment repository. The root App reads its chart
+(`apps/`) from the deployment repository; the *child* Apps it generates read
+their charts from the services repository. The deployment repository is the
+catalogue; the services repository is the warehouse.
+
+Each entry under `services:` is keyed by service name, and its (optional) value
+is a small dictionary. The keys you will use most are:
+
+- **`enabled`** (default `true`): set to `false` to *stop* a service without
+  forgetting it. The App stays, but its workload is scaled down.
+- **`removed`** (default `false`): set to `true` to omit the App entirely, so
+  ArgoCD prunes it from the cluster.
+- **`targetRevision`**: a per-service override of the top-level
+  `source.targetRevision`, so one service can pin a different branch or tag.
+- **`labels`**: labels applied to the service's Kubernetes resources (for
+  example a human-readable `description`).
+
+A bare entry with no value (such as `t01-epics-pvcs:` above) is valid and simply
+inherits every default.
+
+## How one file becomes many Applications
+
+The expansion from "a map of services" to "many ArgoCD Apps" is done by a Helm
+library chart, not by hand. `apps/Chart.yaml` declares a single dependency on
+the **`argocd-apps`** chart, pulled as an **OCI dependency** from
+`oci://ghcr.io/epics-containers/charts`. The one template in the deployment
+repository, `apps/templates/all_apps.yaml`, just includes it:
+
+```yaml
+{{- include "ec-helm-charts.argocd-apps" . -}}
+```
+
+That library template iterates over the `services:` map and emits one child
+`Application` per entry (skipping any marked `removed: true`). Each child App is
+wired to track `services/<service-name>` in the services repository at the
+resolved revision. So the full chain is: you edit `apps/values.yaml` → the root
+App renders the `apps/` chart → `argocd-apps` expands the map → N child Apps →
+each one deploys its service's chart from the services repository.
+
+## Auto-sync: automated, prune, selfHeal
+
+Both the root App and every child App carry the same automated/prune/selfHeal
+policy (child Apps additionally set a couple of `syncOptions`):
+
+```yaml
+syncPolicy:
+  automated:
+    prune: true
+    selfHeal: true
+```
+
+All three behaviours matter:
+
+- **automated** applies changes from Git as soon as ArgoCD sees them, with no
+  manual "Sync" click.
+- **prune** deletes cluster resources once they disappear from Git, so removing
+  a service from `apps/values.yaml` really removes it from the cluster.
+- **selfHeal** reverts *out-of-band* changes. If someone edits a live resource
+  with `kubectl` directly, ArgoCD notices the drift from Git and undoes it.
+
+The combined consequence is that **editing Git is the only action you ever need
+to take**. There is no separate "now deploy it" step, and the cluster cannot
+quietly drift away from what the deployment repository says.
+
+## When does it sync? webhooks vs poll
+
+ArgoCD discovers Git changes in two ways. By default it **polls** each
+repository on a fixed interval, which is **3 minutes** (the ArgoCD default of
+180 seconds). If you configure a **Git webhook** on the deployment repository,
+a push triggers reconciliation immediately instead of waiting for the next poll.
+
+If automation is ever paused, or you simply do not want to wait for the poll,
+you can force a sync from the ArgoCD web UI with the **Sync** button (or the
+`argocd app sync` command). Note that this is a *manual* escape hatch; the
+normal flow needs none of it.
+
+## Revision tracking: branch vs tag
+
+Because `targetRevision` can be set globally and overridden per service, you can
+mix tracking strategies in one deployment repository. Services whose content is
+safe to follow continuously, such as auto-generated OPIs, can track a branch
+like `main`: merge a change in the services repository and it deploys. IOCs are
+usually pinned to a specific **tag** instead, so an IOC changes *only* when its
+tag is deliberately bumped in `apps/values.yaml`. This is how individual IOCs
+get individual version control even though every chart lives in the one shared
+services repository.
+
+## Where Apps live vs where workloads run
+
+It is worth separating two locations that are easy to conflate. The
+`Application` objects are created in the cluster that hosts ArgoCD. The
+*workloads* those Apps deploy are sent wherever each App's `destination.name`
+points, which can be the same cluster or a **different** one. A single ArgoCD
+can therefore reconcile into many target clusters, and a site may run more than
+one ArgoCD instance.
+
+Authorization follows ArgoCD **Projects**. Apps are grouped into a Project
+(named for the domain in this layout), and access is granted per namespace:
+whoever can create resources in a namespace can create Apps that deploy into it.
+An App is created in the same namespace as the resources it manages.
+
+## The ec CLI's role
+
+The {any}`edge-containers-cli` tool (`ec`) is a thin wrapper over `git`,
+`kubectl`, `helm` and `argocd`. Under the ArgoCD backend, selected with
+`EC_CLI_BACKEND=ARGOCD`, it is configured by three environment variables, all
+set for you when you `source ./environment.sh` from your deployment repository:
+
+- **`EC_CLI_BACKEND=ARGOCD`** selects the GitOps backend (it is also the
+  default).
+- **`EC_TARGET`** is `<namespace>/<root-app>`, for example `t01-beamline/t01`.
+- **`EC_SERVICES_REPO`** is the services repository URL, for example
+  `https://github.com/epics-containers/t01-services`.
+
+The important thing to understand is what `ec deploy` actually does. Running:
+
+```bash
+ec deploy bl01t-ea-fastcs-01 2024.12.1
+```
+
+does **not** push anything into the cluster directly. It **records the desired
+state in Git**: it commits and pushes the new `targetRevision` for
+`services.bl01t-ea-fastcs-01` into `apps/values.yaml` in the deployment
+repository, and then runs `argocd app get --refresh` so ArgoCD re-reads Git
+immediately rather than waiting for the next poll. The actual reconciliation is
+done by ArgoCD's auto-sync. In other words, **`ec deploy` does not run
+`argocd app sync`** — it edits Git and lets the controller do its job. That is
+exactly the GitOps model from the top of this page, with `ec` providing a
+convenient front end to it.
+
+For the step-by-step version of all of this, including scaffolding the
+deployment repository, bootstrapping the root App and watching the sync in the
+web UI, see {any}`deploy-argocd`. For the contrasting local, non-Kubernetes
+workflow that the introductory tutorials use, see {any}`deploy-example-instance`.

--- a/docs/explanations/argocd.md
+++ b/docs/explanations/argocd.md
@@ -53,8 +53,9 @@ See the {any}`services-repo` glossary entry for the full definition.
 The **deployment repository** records *which* of those services run, *where*,
 and at *what version*. It is deliberately tiny. You do not clone a ready-made
 one; you scaffold your own (named `t01-deployment` in the worked example) from
-the public `deployment-template-argocd` template. ArgoCD watches this
-repository, not the services repository.
+the public `deployment-template-argocd` template. ArgoCD watches the deployment
+repository for the root Application, while the generated child Applications
+watch the services repository for service charts.
 
 This separation matters because the two repositories change for different
 reasons and at different rates. Service definitions churn as IOCs are developed;

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -23,6 +23,7 @@ tutorials/support_module
 tutorials/setup_k8s
 tutorials/setup_k8s_new_beamline
 tutorials/add_k8s_ioc
+tutorials/deploy_argocd
 tutorials/rtems_setup
 tutorials/rtems_ioc
 ```

--- a/docs/tutorials/deploy_argocd.md
+++ b/docs/tutorials/deploy_argocd.md
@@ -1,0 +1,413 @@
+(deploy-argocd)=
+
+# Deploy IOCs with ArgoCD
+
+This tutorial walks you through the production *continuous deployment* (CD)
+path for epics-containers: you create a **deployment repository** from a
+template, bootstrap a single ArgoCD *root Application*, and then deploy an IOC
+with one `ec deploy` command. From that point on, ArgoCD keeps your cluster in
+sync with what is recorded in git.
+
+By the end you will have:
+
+- a deployment repo (`t01-deployment`) generated from
+  [`deployment-template-argocd`](https://github.com/epics-containers/deployment-template-argocd);
+- a root ArgoCD Application (`t01`) that owns a set of child Applications;
+- the IOC `bl01t-ea-fastcs-01` running on your cluster, with its desired
+  version recorded in git.
+
+The worked example uses the domain **`t01`** (beamline **`bl01t`**), the
+namespace **`t01-beamline`**, and the public services repository
+[`t01-services`](https://github.com/epics-containers/t01-services). Substitute
+your own names throughout.
+
+:::{note}
+This is the GitOps deployment model. If you only want to understand *how* it
+works (the two-repository split, app-of-apps, auto-sync) without running the
+commands, read {any}`../explanations/argocd` first and come back here.
+:::
+
+## Prerequisites
+
+This tutorial assumes the pieces below are already in place. It deliberately
+does **not** repeat the installation steps.
+
+1. **A Kubernetes cluster with ArgoCD installed**, and the `argocd` CLI
+   installed and logged in. The {any}`setup-kubernetes` tutorial installs
+   ArgoCD into a cluster, installs the `argocd` CLI, and shows how to reach the
+   ArgoCD web UI (for a self-hosted install, typically by port-forwarding it to
+   `https://localhost:8081/`). Follow that tutorial first if you have not
+   already.
+
+2. **A workstation with `ec`, `copier`, `git` and `kubectl` available.** See
+   {any}`setup_workstation` for the workstation setup. `ec` must already be
+   installed on your workstation; the generated `environment.sh` only checks
+   that `ec` is present and enables its shell completion (see
+   [Configure your environment](#configure-your-environment) below) — it does
+   not install `ec` for you.
+
+3. **A services repository to deploy from.** A services repo holds the Helm
+   charts and per-service `values.yaml` files that *define* each IOC or service
+   (see {any}`services-repo`). This tutorial uses the public
+   [`t01-services`](https://github.com/epics-containers/t01-services), so you do
+   **not** need to create one. If you want to build your own beamline's
+   services repo, see {any}`setup-k8s-beamline` and {any}`create-beamline`.
+
+4. **A namespace and a matching ArgoCD project for your domain.** ArgoCD
+   Applications are authorised per-namespace and per-project. Create the
+   namespace your IOCs will run in, and an ArgoCD project that is allowed to
+   deploy into it:
+
+   ```bash
+   kubectl create namespace t01-beamline
+   argocd proj create t01-beamline \
+     -d https://kubernetes.default.svc,t01-beamline \
+     -s "*"
+   ```
+
+   :::{note}
+   The deployment template sets the Application `project:` field to your
+   *namespace name* (the `cluster_namespace` you give `copier` below). That is
+   why the ArgoCD project here is named **`t01-beamline`**, matching the
+   namespace. The `-d` flag whitelists the destination
+   `cluster,namespace`; `-s "*"` permits any source repo. Adjust the cluster
+   URL/name if your IOCs run on a different cluster from the one hosting
+   ArgoCD.
+   :::
+
+## Scaffold a deployment repo
+
+The deployment repo is generated from the public
+[`deployment-template-argocd`](https://github.com/epics-containers/deployment-template-argocd)
+template using `copier`:
+
+```bash
+copier copy https://github.com/epics-containers/deployment-template-argocd t01-deployment
+```
+
+:::{note}
+If `copier` is not installed on your workstation you can run it on demand with
+`uvx copier copy https://github.com/epics-containers/deployment-template-argocd t01-deployment`.
+:::
+
+`copier` asks a series of questions (defined in the template's `copier.yml`).
+Answer them as follows for the worked example:
+
+| Prompt | Meaning | Worked-example answer |
+|---|---|---|
+| `domain` | Short name for this collection of IOCs/services. Becomes the **root Application name**. | `t01` |
+| `description` | One-line repo description. | *(accept default)* |
+| `argocd_server` | DNS name of your ArgoCD server, used by `argocd login`. | your ArgoCD server, e.g. `localhost:8081` |
+| `argocd_cluster` | The cluster where ArgoCD **creates the Application objects**. | `in-cluster` *(single-cluster install)* |
+| `cluster_name` | The cluster where the **IOCs run** (`destination.name`). | `in-cluster` *(same cluster)* |
+| `cluster_namespace` | The namespace where IOCs run, **and** the ArgoCD project. | `t01-beamline` |
+| `git_platform` | Where this repo will be hosted. | `github.com` |
+| `github_org` | The GitHub account/org that will own the repo. | *your GitHub account or org* |
+| `deployment_repo` | URL of **this** deployment repo. | *(accept default — `https://github.com/<org>/t01-deployment`)* |
+| `services_repo` | URL of the **services** repo to track. | `https://github.com/epics-containers/t01-services` |
+| `services_release` | Initial branch or tag of the services repo to track. | `main` |
+| `logging_url` | Central log server URL (optional). | `Skip` |
+
+:::{warning}
+The template defaults are placeholders and **will not work unchanged**. The two
+URLs that matter most are `deployment_repo` (must point at the repo you are
+about to push) and `services_repo` (must point at
+`https://github.com/epics-containers/t01-services`). Set both correctly.
+:::
+
+Now create the git repository, commit the generated files, and push to the
+remote you named in `deployment_repo`:
+
+```bash
+git -C t01-deployment init
+git -C t01-deployment add .
+git -C t01-deployment commit -m "Initial deployment repo from template"
+git -C t01-deployment branch -M main
+git -C t01-deployment remote add origin https://github.com/<org>/t01-deployment
+git -C t01-deployment push -u origin main
+```
+
+:::{important}
+ArgoCD must be able to **read** this repo. The simplest option is a public
+repo. If you use a private repo, register the credentials with ArgoCD first —
+otherwise the root Application reports
+`ComparisonError: authentication required`.
+:::
+
+## Tour the generated repo
+
+Before bootstrapping, take a moment to look at what the template produced. The
+deployment repo is deliberately tiny — it records only *which* services run and
+*at what version*; the service content lives in the services repo.
+
+| Path | Role |
+|---|---|
+| `apps.yaml` | The ArgoCD **root Application** ("app of apps"). `source.path: apps` points at the `apps/` chart in this repo; `syncPolicy` is `automated` with `prune` and `selfHeal`. You bootstrap this once. |
+| `apps/values.yaml` | The **control surface** — the only file you (or CI) normally edit. Declares the project, destination, the **services-repo** source, and the `services:` map. |
+| `apps/Chart.yaml` | A Helm chart whose only dependency is the `argocd-apps` library chart, pulled as an **OCI** artifact from `oci://ghcr.io/epics-containers/charts`. |
+| `apps/templates/all_apps.yaml` | A one-line template that expands `apps/values.yaml`'s `services:` map into one child Application per service. |
+| `environment.sh` | Sourced to set the `EC_*` environment variables, enable `ec` shell completion, and log into ArgoCD. |
+
+The root `apps.yaml` looks like this (genericized):
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: t01
+  namespace: t01-beamline
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/background
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  project: t01-beamline
+  destination:
+    name: in-cluster
+    namespace: t01-beamline
+  source:
+    path: apps
+    repoURL: https://github.com/<org>/t01-deployment   # THIS (deployment) repo
+    targetRevision: main
+    helm:
+      version: v3
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+And `apps/values.yaml` — the control surface:
+
+```yaml
+project: t01-beamline
+destination:
+  name: in-cluster
+  namespace: t01-beamline
+source:
+  repoURL: https://github.com/epics-containers/t01-services   # the SERVICES repo
+  targetRevision: main
+
+services:
+  t01-epics-pvcs:
+  t01-epics-opis:
+  t01-epics-gateways:
+```
+
+:::{note}
+Note that `source.repoURL` here points at the **services** repo, not the
+deployment repo. The root Application's `source.repoURL` (in `apps.yaml`) points
+at the deployment repo; every *child* Application sources its Helm chart from
+`services/<service>` in the **services** repo. The template seeds three child
+services: `t01-epics-pvcs` (shared storage), `t01-epics-opis` (auto-generated
+OPIs) and `t01-epics-gateways` (a Channel Access gateway). A bare entry with no
+value — like `t01-epics-pvcs:` — inherits all the defaults above.
+:::
+
+For the full model behind these files — the two-repository split, the
+`argocd-apps` library chart, and how one map becomes many Applications — see
+{any}`../explanations/argocd`.
+
+(configure-your-environment)=
+
+## Configure your environment
+
+The generated `environment.sh` wires up your shell. Source it from the directory
+that contains the deployment repo:
+
+```bash
+source ./t01-deployment/environment.sh
+```
+
+This sets the `EC_*` environment variables, enables `ec` shell completion, and
+logs you into ArgoCD. The variables it exports are:
+
+```bash
+export EC_CLI_BACKEND="ARGOCD"            # use the ArgoCD continuous-deployment backend
+export EC_TARGET=t01-beamline/t01         # <namespace>/<root-app-name>
+export EC_SERVICES_REPO=https://github.com/epics-containers/t01-services
+export EC_LOG_URL=                        # central log server URL (empty — logging_url was Skipped)
+```
+
+`EC_TARGET` is the namespace of your Application objects followed by the root
+Application name (`t01-beamline/t01`); `EC_SERVICES_REPO` is the services repo
+that `ec deploy` validates versions against; `EC_CLI_BACKEND=ARGOCD` selects the
+ArgoCD backend (see {any}`edge-containers-cli`).
+
+:::{note}
+**Site setup varies.** The template's `environment.sh` ends with a generic
+`argocd login <server> --grpc-web --sso`. Adapt this line to your own server and
+auth method. For a self-hosted install reached via port-forward, that is
+typically:
+
+```bash
+argocd login localhost:8081
+```
+
+logging in as `admin` with the password from your ArgoCD install (see
+{any}`setup-kubernetes`).
+:::
+
+Check that the CLI is configured. Until you bootstrap the root Application
+(next section) the target does not exist yet, so `ec ps` reports
+`Target 't01-beamline/t01' not found`:
+
+```bash
+ec ps
+```
+
+That error is expected at this stage; it confirms `ec` is configured and talking
+to ArgoCD with the right target. Once the root Application exists, the same
+command lists your services.
+
+## Bootstrap the root Application
+
+This is the single manual step. From the directory that contains the deployment
+repo, create the root Application from `t01-deployment/apps.yaml`:
+
+```bash
+argocd app create --file t01-deployment/apps.yaml
+```
+
+ArgoCD now creates the root Application `t01`, which in turn creates one child
+Application per entry in `apps/values.yaml`. Within a moment you should see the
+root plus its three seeded children:
+
+```bash
+argocd app list --app-namespace t01-beamline
+```
+
+```
+NAME                       SYNC STATUS   HEALTH
+t01-beamline/t01           Synced        Healthy
+t01-beamline/t01-epics-pvcs       Synced   Healthy
+t01-beamline/t01-epics-opis       Synced   Healthy
+t01-beamline/t01-epics-gateways   Synced   Healthy
+```
+
+:::{note}
+`kubectl apply -f apps.yaml` is the equivalent Kubernetes-native form
+(`apps.yaml` is a valid `Application` resource). It works, but relies on your
+direct cluster RBAC rather than ArgoCD's project authorisation — prefer the
+`argocd` CLI form shown above.
+:::
+
+## Watch it sync in the ArgoCD web UI
+
+Open your ArgoCD web UI (for a port-forwarded install, `https://localhost:8081/`)
+and filter the Applications view by project `t01-beamline`. You will see a card
+for the root `t01` and one for each child. As ArgoCD reconciles, the cards turn
+green (`Synced` / `Healthy`). Click a card to drill into the individual
+Kubernetes resources (StatefulSets, Services, ConfigMaps) it manages — this is
+the quickest way to diagnose a service that will not start.
+
+## Deploy a service
+
+Now deploy an IOC. The service `bl01t-ea-fastcs-01` exists in the
+`t01-services` repo, so you can deploy it directly:
+
+```bash
+ec deploy bl01t-ea-fastcs-01 main
+```
+
+Use a git tag instead of `main` (for example `ec deploy bl01t-ea-fastcs-01 2024.12.1`)
+to pin a specific version.
+
+Here is exactly what happened, and what did **not**:
+
+- `ec` checked that `services/bl01t-ea-fastcs-01` exists in `t01-services` at
+  the requested revision.
+- `ec` then **committed and pushed** an entry under
+  `services.bl01t-ea-fastcs-01` in the deployment repo's `apps/values.yaml`,
+  recording the desired version. This commit is the source of truth.
+- `ec` ran `argocd app get --refresh` to ask ArgoCD to re-read git immediately
+  (otherwise ArgoCD would notice on its next poll — every 3 minutes by default,
+  or instantly if you have configured a git webhook).
+- ArgoCD's **auto-sync** (the `automated`/`prune`/`selfHeal` policy) then
+  reconciles the cluster to match git.
+
+:::{important}
+`ec deploy` does **not** run `argocd app sync`. Under the ArgoCD backend it only
+*records desired state in git* and refreshes ArgoCD; the actual reconciliation
+is performed by ArgoCD's auto-sync. To force an immediate sync manually (for
+example if auto-sync has been paused), use the **Sync** button in the ArgoCD web
+UI, or `argocd app sync`.
+:::
+
+Verify the deployment with `ec ps`:
+
+```bash
+ec ps
+```
+
+```
+ name                 label     version   ready   deployed
+ t01-epics-pvcs       service   main      True    2026-06-25T09:10:00Z
+ t01-epics-opis       service   main      True    2026-06-25T09:10:00Z
+ t01-epics-gateways   service   main      True    2026-06-25T09:10:00Z
+ bl01t-ea-fastcs-01   service   main      True    2026-06-25T09:14:00Z
+```
+
+And confirm the git record — pull the deployment repo and look at
+`apps/values.yaml`:
+
+```bash
+git -C t01-deployment pull
+```
+
+```yaml
+services:
+  t01-epics-pvcs:
+  t01-epics-opis:
+  t01-epics-gateways:
+  bl01t-ea-fastcs-01:
+    enabled: true
+    targetRevision: main
+    labels:
+      description: ...
+```
+
+A new card for `bl01t-ea-fastcs-01` also appears in the ArgoCD web UI.
+
+## Stop, start and remove a service (optional)
+
+The rest of the service lifecycle is also driven through `ec`:
+
+- `ec stop bl01t-ea-fastcs-01` / `ec start bl01t-ea-fastcs-01` — pause or resume
+  a service as a **live patch**. Add `--commit` to also record the change in
+  `apps/values.yaml` (without `--commit`, `selfHeal` would otherwise revert a
+  manual cluster change — the live patch sets the parameter directly).
+- `ec delete bl01t-ea-fastcs-01` — removes the entry from `apps/values.yaml`,
+  commits and pushes; auto-sync then prunes the resources from the cluster.
+- `ec logs bl01t-ea-fastcs-01` — stream a service's logs.
+- `ec monitor` — a terminal UI to browse and manage all services at once.
+
+## Clean up
+
+Because all desired state lives in git, teardown and rebuild are cheap and
+reversible. Delete the root Application and, via `prune` plus finalizers, all of
+its children are removed:
+
+```bash
+argocd app delete t01-beamline/t01 -y
+```
+
+Re-bootstrap any time with `argocd app create --file t01-deployment/apps.yaml` —
+ArgoCD recreates everything from git (the persistent volume claims behind
+`t01-epics-pvcs` are usually the slow part).
+
+:::{note}
+The cluster is fully reconstructable from git, with one caveat: IOC autosave
+files held inside persistent volumes are *not* in git, so deleting the
+underlying PVCs discards that state.
+:::
+
+## Next steps
+
+- {any}`../explanations/argocd` — the GitOps model in depth: two repositories,
+  app-of-apps, auto-sync, and the `ec` CLI's role.
+- {any}`helm` — deploy with pure Helm instead of ArgoCD (the manual, non-GitOps
+  alternative).
+- {any}`add_k8s_ioc` — add and configure your own IOC instances in a services
+  repo, ready to deploy here.
+- {any}`deploy-example-instance` — the local / `docker compose` deployment path,
+  for contrast with this cluster-based CD flow.

--- a/docs/tutorials/deploy_argocd.md
+++ b/docs/tutorials/deploy_argocd.md
@@ -276,7 +276,7 @@ root plus its three seeded children:
 argocd app list --app-namespace t01-beamline
 ```
 
-```
+```text
 NAME                       SYNC STATUS   HEALTH
 t01-beamline/t01           Synced        Healthy
 t01-beamline/t01-epics-pvcs       Synced   Healthy
@@ -339,7 +339,7 @@ Verify the deployment with `ec ps`:
 ec ps
 ```
 
-```
+```text
  name                 label     version   ready   deployed
  t01-epics-pvcs       service   main      True    2026-06-25T09:10:00Z
  t01-epics-opis       service   main      True    2026-06-25T09:10:00Z


### PR DESCRIPTION
Addresses **theme #2** of `DOCS-REVIEW.md` — the ArgoCD deployment model had no public tutorial or explanation page (it appeared only in passing prose / WIP mentions). Adds two new, **generic** public pages derived from the internal DLS developer-guide docs but with all Diamond-specifics removed.

## New pages
- **`docs/explanations/argocd.md`** — *How ArgoCD Deploys Your IOCs* (conceptual): GitOps model, the **services repo vs deployment repo** split, the **app-of-apps** root Application, the `argocd-apps` OCI library chart that expands `apps/values.yaml` into one child Application per service, auto-sync (`prune` + `selfHeal`), webhooks vs the 3-min poll, branch-vs-tag tracking, and what `ec deploy` actually does.
- **`docs/tutorials/deploy_argocd.md`** — *Deploy IOCs with ArgoCD* (hands-on): scaffold a deployment repo from `deployment-template-argocd` (with the copier prompt table), `source ./environment.sh`, bootstrap the root app with `argocd app create --file apps.yaml`, `ec deploy` a service from the public `t01-services`, watch it sync, and clean up.

Wired `tutorials/deploy_argocd` into the tutorials toctree; `explanations.md` uses a `:glob:` so `argocd.md` auto-includes (no edit needed there).

## Genericization
No Argus/Pollux/Acastus/Hylas, no `*.diamond.ac.uk`/`gitlab.diamond`, no FedID, **`source ./environment.sh` instead of `module load`**, `github.com` repos, worked example `t01`/`bl01t` against the public `t01-services` (the deployment repo is *scaffolded* from `deployment-template-argocd`, since there's no public `t01-deployment` to clone).

## Verification
- Every command / value-key / env var checked against the implementation: `deployment-template-argocd` (copier prompts, `apps.yaml.jinja`, `apps/values.yaml.jinja`, `environment.sh.jinja`), the `ec` ARGOCD backend (`argo_commands.py`, `cli.py`), and `ec-helm-charts/argocd-apps`. Notably: `EC_TARGET=<namespace>/<root-app>`, `project = cluster_namespace`, root `destination.name = argocd_cluster` vs child `destination.name = cluster_name`, and **`ec deploy` records desired state in git + `argocd app get --refresh` — it does *not* run `argocd app sync`**.
- DLS-leakage grep is clean.
- `sphinx-build --fail-on-warning --keep-going` builds with **0 warnings** (all cross-refs resolve, no orphan/toctree issues).

Built via a multi-agent workflow (research → design → draft → adversarial verify → revise) in an isolated worktree. For review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new explanation page covering the ArgoCD/GitOps deployment model, including repository layout, how sync and auto-reconciliation work, and what “target revision” means across deployments.
  * Updated the tutorials index with a new ArgoCD deployment walkthrough.
  * Added a complete ArgoCD production deployment tutorial, including bootstrapping the setup, deploying a specific IOC, verification, common lifecycle commands, and cleanup notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->