### PR TITLE
Fix docs build: disambiguate 'helm' cross-reference

### DIFF
--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -68,7 +68,7 @@ The variables are as follows:
 
 - **EC_CLI_BACKEND**: selects which backend `ec` drives. One of `ARGOCD`
   (the default), `K8S`, or `DEMO`. The set of available commands and options
-  changes per backend — see [](helm). (`ec -b/--backend`.)
+  changes per backend — see {ref}`helm`. (`ec -b/--backend`.)
 
 ### Optional variables
 


### PR DESCRIPTION
The CI `docs / build` job failed on `main` after #234 merged.

`sphinx-build` runs with `--fail-on-warning`, and the new `[](helm)` link in `docs/reference/environment.md` was ambiguous — `helm` matched both the `(helm)=` label and the `reference/helm` doc:

```
environment.md:69: WARNING: more than one target found for 'myst' cross-reference helm:
could be :std:ref:`The ec Backend Model` or :std:doc:`The ec Backend Model` [myst.xref_ambiguous]
```

Fix: target the label explicitly with `{ref}`helm``. Verified locally — `tox -e docs` now builds clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)