### PR TITLE
docs: tidy Python setup guidance — venv→uv stragglers + 3.10→3.13 baseline (theme #4)

### DIFF
--- a/docs/how-to/builder2ibek.md
+++ b/docs/how-to/builder2ibek.md
@@ -11,7 +11,11 @@ TODO: this page is WIP and will be updated soon.
 `builder2ibek` is a tool to convert DLS builder XML to ibek instance YAML.
 It is for working with converting IOC instances to epics-containers.
 
-At present (until a new python app distribution mechanism is in place) it
-is installed at DLS in the following location:
+`builder2ibek` is published on [PyPI](https://pypi.org/project/builder2ibek/).
+Install it with [uv](https://docs.astral.sh/uv/):
 
-`/dls_sw/work/python3/ec-venv/bin/builder2ibek`
+```bash
+uv tool install builder2ibek
+```
+
+Or run it without installing first using `uvx builder2ibek`.

--- a/docs/tutorials/setup_workstation.md
+++ b/docs/tutorials/setup_workstation.md
@@ -6,7 +6,8 @@ The tools you need to install are:
 
 - Visual Studio Code
 - a container platform: podman (plus docker-compose)
-- Python 3.10 or later + a Python virtual environment
+- Python 3.10 or later (uv can also install this for you)
+- uv, to install the Python CLI tools (copier and ec)
 - git client for version control (Configured for the current user, with read-write access for Repository Contents and Workflows.)
 
 If you prefer to use a virtual machine, we provide a VirtualBox appliance with all the software pre-installed. This is the easiest way to get started.
@@ -79,7 +80,7 @@ This VM has the following software pre-installed:
 
 You will need to complete the following steps to personalize the VM:
 - Set up your github credentials
-- Set up your python virtual environment
+- Install `uv` and the Python CLI tools (copier and ec)
 - Set up your podman CLI completion if you want it
 
 Now jump to {ref}`cli-completion` below.

--- a/docs/tutorials/setup_workstation.md
+++ b/docs/tutorials/setup_workstation.md
@@ -6,7 +6,7 @@ The tools you need to install are:
 
 - Visual Studio Code
 - a container platform: podman (plus docker-compose)
-- Python 3.10 or later (uv can also install this for you)
+- Python 3.13 or later (uv can also install this for you)
 - uv, to install the Python CLI tools (copier and ec)
 - git client for version control (Configured for the current user, with read-write access for Repository Contents and Workflows.)
 
@@ -73,7 +73,7 @@ Now start the VM and log in as `ec-demo` with password `demo1`.
 
 This VM has the following software pre-installed:
 - Ubuntu 22.04
-- Python 3.10
+- Python 3.13
 - Visual Studio Code
 - Podman
 - zsh shell with oh-my-zsh
@@ -211,10 +211,10 @@ podman completion zsh > ~/.oh-my-zsh/completions/_podman
 ### Install Python
 
 :::{Note}
-**DLS Users**: for this step just use `module load python/3.11`
+**DLS Users**: for this step just use `module load python/3.13`
 :::
 
-Go ahead and install Python if it is not already installed, the minimum version you should use is 3.10. Virtualbox Appliance users will already have Python 3.10 installed.
+Go ahead and install Python if it is not already installed, the minimum version you should use is 3.13. Virtualbox Appliance users will already have Python 3.13 installed.
 
 There are instructions for installing Python on all platforms here:
 <https://docs.python-guide.org/starting/installation/>


### PR DESCRIPTION
## Theme #4 — `uv`/`uvx` vs `venv`/`pip` drift (+ Python baseline bump)

Two related cleanups to the Python setup guidance. The bulk of the migration to
`uv tool install` already landed earlier (branch `use-uv-not-venv`, now in
`main`); this PR clears the **stragglers** and bumps the documented Python baseline.

### 1. venv/pip → uv stragglers

| File | Before | After |
|---|---|---|
| `setup_workstation.md` (intro list) | `Python 3.10 or later + a Python virtual environment` | two bullets: `Python 3.x or later (uv can also install this for you)` + `uv, to install the Python CLI tools (copier and ec)` |
| `setup_workstation.md` (VM personalize steps) | `Set up your python virtual environment` | `Install \`uv\` and the Python CLI tools (copier and ec)` |
| `docs/how-to/builder2ibek.md` | stale `/dls_sw/work/python3/ec-venv/bin/builder2ibek` path | `uv tool install builder2ibek` (or `uvx builder2ibek`) — the tool is now on PyPI |

### 2. Python baseline `3.10` → `3.13` (all pages)

`setup_workstation.md` was the only page mentioning a Python version. Every
reference now reads **3.13**:

- intro bullet + "minimum version you should use" → 3.13 *(plain recommendations)*
- ⚠️ VirtualBox appliance "pre-installed" list and "will already have Python …
  installed" → 3.13 — **the OVA image lives outside this repo; please confirm it
  actually ships 3.13.**
- ⚠️ DLS `module load python/3.11` → `python/3.13` — **please confirm a
  `python/3.13` module exists at DLS.**

The `R3.14.x` strings in `autosave.md` / `builder2ibek.support.md` are EPICS base
versions, not Python, and are left untouched.

### Deliberately left untouched

- **`docs/reference/environment.md`** — owned by a parallel theme-#3 session.
- The historical ADRs (`0002…`, `0005…`).
- `overview.md` / `introduction.md` "lightweight virtual environment" — a
  container metaphor, not a Python venv.
- `docs/demo/pv_access_tests.sh` — a legitimate p4p test venv.
- The `TODO: WIP` banner on `builder2ibek.md` — the page still lacks a
  usage/subcommands section (a separate finding), so it remains genuinely WIP.

### Verification

- `uv run --no-sync sphinx-build --fail-on-warning` → **0 warnings**.
- Adversarial review across three lenses (accuracy vs. implementation,
  completeness sweep, conventions/markdown) — all pass, no blockers. `builder2ibek`
  package name + console script confirmed against `pyproject.toml` and PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
