### PR TITLE
docs: fix stale templates symlink target in copier_update

### DIFF
--- a/DOCS-REVIEW.md
+++ b/DOCS-REVIEW.md
@@ -278,7 +278,7 @@ Both were checked against the current local working copies of the implementation
 - **Fix:** Add `builder2ibek xml2yaml <ioc.xml> --yaml <out.yaml>` and mention `beamline2yaml`, `autosave`, `migrate-autosave`, `db-compare`, `reconvert`.
 - **Evidence:** `builder2ibek.md:11-12`; `builder2ibek/src/builder2ibek/__main__.py:12,34-50,53,66,82,137,169`.
 
-#### `docs/how-to/copier_update.md` — wrong templates symlink target [minor, wrong-path]
+#### `docs/how-to/copier_update.md` — wrong templates symlink target [minor, wrong-path] — FIXED (PR pending)
 - **Location:** line 40 (`points at ../../include/ioc/templates`)
 - **Issue:** No such path exists; templates symlinks point at `../../.helm-shared/templates`.
 - **Fix:** Change to `../../.helm-shared/templates`.

--- a/docs/how-to/copier_update.md
+++ b/docs/how-to/copier_update.md
@@ -37,7 +37,7 @@ You can supply the VERSION_NUMBER of the template you want or omit the `-r` opti
 
 This will update your project in place. You should then inspect the changes using git (the source control pane in vscode is excellent for this purpose) and commit them to your repository. Once you are happy with the changes you can test them by re-deploying some of your IOC instances. When everything is working you can push the changes to your repository.
 
-For example, in version 3.4.0 the `services-template-helm` changed the way that the configmap is created for each IOC instance. This added a soft-link **templates** folder that points at **../../include/ioc/templates**. Looking at what changes happened in the example IOC will help you to understand what changes you might need to make in your own IOC instances. Copier migrations will attempt to make these changes for you but it is recommended to check that they have been done correctly.
+For example, in version 3.4.0 the `services-template-helm` changed the way that the configmap is created for each IOC instance. This added a soft-link **templates** folder that points at **../../.helm-shared/templates**. Looking at what changes happened in the example IOC will help you to understand what changes you might need to make in your own IOC instances. Copier migrations will attempt to make these changes for you but it is recommended to check that they have been done correctly.
 
 
 Updating a Generic IOC Repository


### PR DESCRIPTION
## Theme 7 — Helm-chart value-key/path drift

`docs/how-to/copier_update.md` line 40 described the configmap soft-link `templates` folder as pointing at `../../include/ioc/templates`. That path no longer exists — the symlink points at `../../.helm-shared/templates` (part of the `helm/shared` → `.helm-shared` rename).

### What this PR does
- Updates the example path to `../../.helm-shared/templates`.

### Verification
- `readlink services-template-helm/template/services/.ioc_template/templates` → `../../.helm-shared/templates`.
- `uv run --no-sync sphinx-build --fail-on-warning -b html docs` passes.

This clears one of the two remaining theme-7 pages (excluding rtems). The last one, `docs/reference/k8s_resources.md`, is best handled as part of that page's full `ec template` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)