### PR TITLE
docs: update pattern vendoring for ibek.manifest.yaml and the wrapped lock

### DIFF
--- a/DOCS-REVIEW.md
+++ b/DOCS-REVIEW.md
@@ -16,6 +16,8 @@ Both were checked against the current local working copies of the implementation
 
 **Caveat:** `i21-deployment` was not available locally (it lives on Diamond GitLab), so `t01-deployment` was used as the deployment-repo stand-in. All findings are stated against local working copies; line numbers refer to those copies.
 
+**Update (issue #250 / ibek#361):** the vendoring findings below were written when `ibek pattern` stamped a `# Vendored from … — DO NOT EDIT` header into every vendored file. That header is gone: vendored files are now byte-identical to the library, `runtime-lock.yaml` is the only record of which files under `config/` are copies, and `ibek pattern check` (pre-commit + `ci_verify.sh`) is what enforces "never hand-edit". A pattern may also carry an `ibek.manifest.yaml` allow-list declaring which of its files are vendored. The **Fix** prescriptions below have been reworded so that acting on them does not reintroduce the header; the findings themselves are unchanged.
+
 ---
 
 ## Executive summary
@@ -33,7 +35,7 @@ Both were checked against the current local working copies of the implementation
 
 ### Top themes (highest impact)
 
-1. **`ibek pattern` runtime-support vendoring is undocumented everywhere.** The entire vendoring model (`add/update/check/restore/schema`, `runtime-lock.yaml`, per-instance `ioc.schema.json`, DO-NOT-EDIT headers, strict sha256 integrity, `DIRTY` opt-out, central pattern libraries) appears in zero public or internal pages — despite being wired into pre-commit, CI and Renovate. New pages are needed.
+1. **`ibek pattern` runtime-support vendoring is undocumented everywhere.** The entire vendoring model (`add/update/check/restore/schema`, `runtime-lock.yaml`, per-instance `ioc.schema.json`, the never-hand-edit rule, strict sha256 integrity, `DIRTY` opt-out, `ibek.manifest.yaml`, central pattern libraries) appears in zero public or internal pages — despite being wired into pre-commit, CI and Renovate. New pages are needed.
 2. **ArgoCD deployment model has no tutorial/reference page.** The production CD path (deployment repo, app-of-apps, `apps/values.yaml` control surface, `ec deploy` → git commit → autosync) is only mentioned in passing prose.
 3. **`ec` backend model is undocumented and `reference/environment.md` is wrong.** Three documented env vars no longer exist; the available commands/options change per backend; there is no `ec` command reference page.
 4. **`uv`/`uvx` vs `venv`/`pip` drift.** Tutorials switched to `uv tool install`, but intro bullets, environment.sh fallbacks, and a few reference pages still teach `python -m venv`/`pip`.
@@ -627,7 +629,7 @@ Both were checked against the current local working copies of the implementation
 #### `docs/how-tos/new-ioc.md` — no runtime-support vendoring section [critical, missing-content]
 - **Location:** "Edit the IOC Configuration", lines 48-54
 - **Issue:** Tells engineers to supply only `config/ioc.yaml` (or hand-written st.cmd/ioc.subst). The current workflow requires vendoring runtime support into `config/` via `ibek pattern`, enforced by pre-commit (`ibek-ioc-schema`, `ibek-pattern-check`) and `ci_verify.sh` (loops `services/*/runtime-lock.yaml`). A StreamDevice IOC fails CI/pre-commit and lacks `ioc.schema.json` without it.
-- **Fix:** Add a "Vendoring Runtime Support" section: `ibek pattern add [<library>:]<pattern>[@<tag>] services/<instance>`, `update`, `check`, `restore`; default libraries; DO-NOT-EDIT/sha256-pinned files (never hand-edit; CI fails on mismatch unless marked `DIRTY`); one-off editable `*.ibek.support.yaml` in config/. Cross-link the services-template-helm README "Vendoring runtime support".
+- **Fix:** Add a "Vendoring Runtime Support" section: `ibek pattern add [<library>:]<pattern>[@<tag>] services/<instance>`, `update`, `check`, `restore`; default libraries; sha256-pinned files (never hand-edit — a vendored copy carries no marker of its own, so `runtime-lock.yaml` is the record and CI fails on mismatch unless marked `DIRTY`); one-off editable `*.ibek.support.yaml` in config/. Cross-link the services-template-helm README "Vendoring runtime support".
 - **Evidence:** `new-ioc.md:48-54`; `README.md.jinja:19-67`; `.pre-commit-config.yaml:58-73`; `ci_verify.sh:67-81`; `ibek/.../pattern_cmds/commands.py:66-141`, `sources.py:23-27`.
 
 #### `docs/how-tos/new-ioc.md` — no deploy steps [minor, missing-content]
@@ -740,8 +742,8 @@ Both were checked against the current local working copies of the implementation
 
 #### Public: new how-to page for `ibek pattern` vendoring [critical, missing-content]
 - **Repo:** public, `docs/how-to/vendor-runtime-support.md` (NEW)
-- **Issue:** No public how-to page documents the five subcommands, the `[library:]name[@version]` syntax, the `config/`-vendored file set vs instance-root `runtime-lock.yaml`/`ioc.schema.json`, the DO-NOT-EDIT headers, the strict per-branch sha256 check, the `DIRTY` opt-out, built-in libraries, or the `IBEK_PATTERN_LIBRARIES`/`IBEK_ALLOW_DIRTY`/`IBEK_SCHEMA_CACHE` env vars.
-- **Fix:** Add `docs/how-to/vendor-runtime-support.md` (to the how-to TOC) documenting the syntax; the five commands from the repo root (e.g. `ibek pattern add ibek-runtime-streamdevice:lakeshore340@1.0.0 services/<instance>`); placement (`config/` is the ConfigMap payload; `runtime-lock.yaml`/`ioc.schema.json` at instance root); integrity policy + `DIRTY # <reason>`; built-in libraries + env vars; the DO-NOT-EDIT header; the Renovate flow (Renovate bumps the version string, maintainer runs `ibek pattern update`). Cross-link ADR 0004.
+- **Issue:** No public how-to page documents the five subcommands, the `[library:]name[@version]` syntax, the `config/`-vendored file set vs instance-root `runtime-lock.yaml`/`ioc.schema.json`, the never-hand-edit rule, the strict per-branch sha256 check, the `DIRTY` opt-out, built-in libraries, or the `IBEK_PATTERN_LIBRARIES`/`IBEK_ALLOW_DIRTY`/`IBEK_SCHEMA_CACHE` env vars.
+- **Fix:** Add `docs/how-to/vendor-runtime-support.md` (to the how-to TOC) documenting the syntax; the five commands from the repo root (e.g. `ibek pattern add ibek-runtime-streamdevice:lakeshore340@1.0.0 services/<instance>`); placement (`config/` is the ConfigMap payload; `runtime-lock.yaml`/`ioc.schema.json` at instance root); integrity policy + `DIRTY # <reason>`; built-in libraries + env vars; the never-hand-edit rule (vendored files are byte-identical to the library, so `runtime-lock.yaml` is the only thing that says which files are copies); the Renovate flow (Renovate bumps the version string, maintainer runs `ibek pattern update`). Cross-link ADR 0004.
 - **Evidence:** `docs/how-to/` listing (absent); `ibek/.../pattern_cmds/{commands,sources,lock,vendor,schema}.py`; ADR 0004; `services-template-helm` hooks/CI/renovate; `README.md.jinja:19-63`.
 
 #### Public: new tutorial/reference page for the ArgoCD deployment model [critical, missing-content]
@@ -788,8 +790,8 @@ Both were checked against the current local working copies of the implementation
 
 #### Internal: new-ioc.md (topics path) — same vendoring gap [critical, missing-content]
 - **Repo:** internal, `topics/epics-containers/docs/how-tos/new-ioc.md`
-- **Issue:** Same gap as the developer-guide-root `new-ioc.md` (no vendoring section). A StreamDevice IOC has no documented path; engineers could hand-edit a DO-NOT-EDIT vendored file and break CI's sha256 check. The public create_ioc tutorial it cross-links does not cover vendoring either.
-- **Fix:** Add a "Vendoring Runtime Support" section (commands, default libraries, DO-NOT-EDIT/sha256, `DIRTY`, one-off editable `*.ibek.support.yaml`). Cross-link the services-template-helm README as authoritative (do NOT rely on the public create_ioc tutorial).
+- **Issue:** Same gap as the developer-guide-root `new-ioc.md` (no vendoring section). A StreamDevice IOC has no documented path; engineers could hand-edit a vendored file — which looks like any other file under `config/` — and break CI's sha256 check. The public create_ioc tutorial it cross-links does not cover vendoring either.
+- **Fix:** Add a "Vendoring Runtime Support" section (commands, default libraries, never-hand-edit/sha256, `DIRTY`, one-off editable `*.ibek.support.yaml`). Cross-link the services-template-helm README as authoritative (do NOT rely on the public create_ioc tutorial).
 - **Evidence:** `new-ioc.md:48-54`; grep 0 for `ibek pattern`/`runtime-lock`/`vendor` in internal docs; `README.md.jinja:19-67`; `.pre-commit-config.yaml:58-73`; `ci_verify.sh:67-81`; `pattern_cmds/commands.py:66-141`, `sources.py:23-27`; `create_ioc.md:117,214,327-332`.
 
 ---

--- a/docs/how-to/copier_update.md
+++ b/docs/how-to/copier_update.md
@@ -45,6 +45,17 @@ After a **major** template update you may need to re-vendor runtime support for 
 ```bash
 ibek pattern add <library>:<pattern>@<tag> services/<instance>
 ```
+
+If an instance already has a `runtime-lock.yaml` that predates the current lock
+format, `add` refuses rather than rewrite half of it:
+
+```none
+error: services/<instance>/runtime-lock.yaml predates destination-root-relative lock keys, and this would leave <pattern>, <pattern> half-rewritten; run 'ibek pattern update' (all patterns) first
+```
+
+Do exactly that first — `ibek pattern update services/<instance>` with no
+`--name` — then `add`. See {any}`legacy-runtime-lock` for what the old format
+looks like and what changes when it is rewritten.
 :::
 
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -120,6 +120,40 @@ for more information
 
 Solution: make sure your docker compose is up to date
 
+(legacy-runtime-lock)=
+
+## `ibek pattern` rejects an existing `runtime-lock.yaml`
+
+Problem: on an instance you have not touched, `ibek pattern check
+services/<instance>` fails with a `missing vendored file` line per file and:
+
+```none
+error: <pattern>: this lock predates destination-root-relative keys (no 'patterns:' root key) and its hashes cover the removed vendored header; run 'ibek pattern update' to rewrite it
+```
+
+Or `ibek pattern add …` / `ibek pattern update --name …` on that instance
+refuses to run at all:
+
+```none
+error: services/<instance>/runtime-lock.yaml predates destination-root-relative lock keys, and this would leave <pattern>, <pattern> half-rewritten; run 'ibek pattern update' (all patterns) first
+```
+
+Solution: the instance's `runtime-lock.yaml` is in the older format — no
+`version:`/`patterns:` wrapper, file keys relative to `config/` instead of to the
+instance root, and hashes covering the `DO NOT EDIT` header that vendored files
+no longer carry. Re-vendor the whole lock once:
+
+```bash
+ibek pattern update services/<instance>
+```
+
+Omit `--name`: every pattern has to be re-vendored together at its pinned
+version, and `ibek` refuses to rewrite only part of an old lock. The commit that
+follows shows the lock in its new shape and each vendored file one line shorter
+— the header going away. It is a one-off per instance; afterwards `add`,
+`update --name` and `check` all behave normally. See {any}`detector-plugins` for
+the vendoring workflow.
+
 ## Disable recursive git-repository scanning in VSCode
 
 Generic IOC dev containers mount many git repositories under `/epics/support`

--- a/docs/tutorials/add_k8s_ioc.md
+++ b/docs/tutorials/add_k8s_ioc.md
@@ -134,8 +134,14 @@ This copies the files into `config/`, records each one with a pinned version and
 `sha256` hash in `services/bl02t-ea-cam-01/runtime-lock.yaml`, and refreshes
 `ioc.schema.json` so the new entities validate too. Because `config/` is mounted
 as the ConfigMap, keep its total content under 1 MiB. `ibek pattern check`
-verifies the vendored files still match the lock. The simulated detector above
-needs none of this, so you can skip the section.
+verifies the vendored files still match the lock; the repo's pre-commit hook runs
+it over the instances you touch and `ci_verify.sh` runs it over every instance in
+CI, and that is what enforces the rule, because a vendored copy is otherwise
+indistinguishable from a file you wrote.
+Every file under `config/` that the lock lists belongs to the library: edit the
+pattern there and re-vendor, never the copy. {any}`detector_plugins` walks
+through the whole workflow. The simulated detector above needs none of this, so
+you can skip the section.
 
 ## Deploy it
 

--- a/docs/tutorials/custom_pattern.md
+++ b/docs/tutorials/custom_pattern.md
@@ -18,8 +18,11 @@ You will use the same `bl01t` worked example; substitute your own names
 throughout.
 
 :::{note}
-`ibek pattern` runs on your **workstation** and needs **ibek ≥ 4.6.1**. If
-`ibek` is not installed, run `uv tool install ibek --upgrade`.
+`ibek pattern` runs on your **workstation**. The `ibek.manifest.yaml` and
+`runtime-lock.yaml` shown on this page need an `ibek` **newer than 4.6.2**:
+4.6.2 and earlier ignore the manifest, stamp a `DO NOT EDIT` header into every
+vendored file and write the older lock format. Install or refresh it with
+`uv tool install ibek --upgrade`, and confirm with `ibek --version`.
 :::
 
 ## Fork the pattern library
@@ -104,6 +107,49 @@ The `ADCore` plugins it references are compiled into every AreaDetector image,
 so this pattern needs **no `.db` / `.template` of its own** — it only adds the
 `ibek` entities that instantiate and connect them at runtime.
 
+### Optional: declare what gets vendored
+
+`basicPlugins` holds one file and every byte of it belongs in the IOC, so there
+is nothing to declare. That is the usual case: **a pattern with no manifest
+vendors every file in its folder into the instance's `config/`**, exactly as
+patterns always have.
+
+Write one only when the folder holds something an IOC must not receive — a
+`README`, a datasheet, device notes you want browsable in the library.
+Everything in `config/` is mounted into the IOC container (and on Kubernetes it
+*is* the ConfigMap), so whatever lands there travels to the beamline. An
+`ibek.manifest.yaml` at the root of the pattern folder lists what counts as a
+runtime file:
+
+```yaml
+version: 1
+vendor:
+  - src: '.*\.(template|db|req|proto|protocol|ibek\.support\.yaml|pvi\.device\.yaml)$'
+    dest: config
+```
+
+`src` is a regular expression that must match a file's **whole** path within the
+pattern folder — `ibek` matches with `re.fullmatch`, so a rule of `'\.proto$'`
+on its own matches nothing; lead each one with `.*`. `dest` is where the matched
+files land, relative to the instance root, and `config` is the only destination
+a services repo needs.
+
+The list is an **allow-list**: a file matched by no entry is not vendored, which
+is exactly how the `README` stays out of the IOC. The manifest itself is never
+vendored either. That cuts both ways — a runtime file your rules forget is
+dropped just as quietly, with no error and a passing `ibek pattern check` — so
+the alternation has to name every extension the pattern really ships. Only a
+manifest matching *nothing at all* is reported as a mistake.
+
+Narrowing a manifest later takes effect the next time the instance is
+re-vendored **from a version that carries it**. A bare
+`ibek pattern update services/<instance>` re-fetches each pattern at the version
+already pinned, so a manifest added after that tag is not seen: cut a new tag
+and re-pin with `-v <tag>` (below, a local `--source` pins `HEAD`, so re-running
+`ibek pattern add` is enough). When it does re-vendor, files the manifest
+stopped matching are deleted from `config/`, so the instance never keeps a copy
+the pattern no longer claims.
+
 ## Create a fresh instance to vendor into
 
 Make a new instance `bl01t-ea-cam-02` exactly as you made `bl01t-ea-cam-01` in
@@ -151,8 +197,8 @@ ibek pattern add --source ../ibek-runtime-support basicPlugins services/bl01t-ea
 ```
 
 This writes `basicPlugins.ibek.support.yaml` into
-`services/bl01t-ea-cam-02/config/` with a `# Vendored from … — DO NOT EDIT`
-header and records its `sha256` in `services/bl01t-ea-cam-02/runtime-lock.yaml`.
+`services/bl01t-ea-cam-02/config/` — an exact copy of the file in your fork —
+and records its `sha256` in `services/bl01t-ea-cam-02/runtime-lock.yaml`.
 That is all the vendor step needs: at container start `ibek runtime generate2
 config` discovers the vendored support file and loads your entity — no image
 rebuild, and nothing else to wire up.
@@ -160,16 +206,37 @@ rebuild, and nothing else to wire up.
 The lock now pins the pattern. A local source pins to `HEAD`:
 
 ```yaml
-basicPlugins:
-  version: HEAD
-  source: ../ibek-runtime-support
-  files:
-    basicPlugins.ibek.support.yaml: "sha256:…"
+version: 1
+patterns:
+  basicPlugins:
+    version: HEAD
+    source: ../ibek-runtime-support
+    files:
+      config/basicPlugins.ibek.support.yaml: sha256:…
 ```
+
+The `files:` keys are relative to the **instance root**, which is why `config/`
+appears in them.
+
+:::{warning}
+Keep editing the pattern **in your fork** and re-run `ibek pattern add` — never
+the copy under `config/`. The copy looks like any other file, and only the lock
+records that it is not yours: an edit there is overwritten by the next `add`,
+`update` or `restore`, and fails `ibek pattern check` before that.
+:::
 
 `ibek pattern check services/bl01t-ea-cam-02` re-hashes the vendored file and
 exits non-zero if it has drifted from the lock — run it in CI or a pre-commit
-hook to guarantee the committed `config/` matches what was pinned.
+hook to guarantee the committed `config/` matches what was pinned. Because the
+copy is byte-for-byte the file in the library, plain `diff` works as a second
+opinion:
+
+```bash
+diff -r services/bl01t-ea-cam-02/config/ ../ibek-runtime-support/basicPlugins/
+```
+
+Vendored files that appear on both sides compare equal; your own `ioc.yaml` and
+anything the pattern does not vendor show up as `Only in …` lines.
 
 ## Use the new entity
 
@@ -247,6 +314,7 @@ it shareable:
 A pattern's file-set is **not** fixed to a single file. The lock simply hashes
 a *file list*, so a pattern may also ship `.template` / `.db`, autosave `.req`
 files, or a `.pvi.device.yaml` screen descriptor alongside its support yaml —
-whatever the support definition references. {any}`stream_device` vendors exactly
-such a multi-file device-support pattern.
+whatever the support definition references. All of it is vendored unless an
+`ibek.manifest.yaml` narrows the set. {any}`stream_device` vendors exactly such
+a multi-file device-support pattern.
 :::

--- a/docs/tutorials/detector_plugins.md
+++ b/docs/tutorials/detector_plugins.md
@@ -28,8 +28,10 @@ By the end you will have:
 :::{note}
 This continues directly from {any}`create_ioc`; you need the
 `bl01t-ea-cam-01` instance from that tutorial. Run the `ibek pattern` commands
-on your **workstation** with **ibek ≥ 4.6.1** installed (or prefix them with
-`uvx --from ibek`).
+on your **workstation** with an **ibek newer than 4.6.2** installed (or prefix
+them with `uvx --from 'ibek>4.6.2'`). 4.6.2 and earlier stamp a `DO NOT EDIT`
+header into each vendored file and write an older `runtime-lock.yaml` than the
+one shown below; `uv tool install ibek --upgrade` refreshes an existing install.
 :::
 
 ## Vendor the plugin pattern
@@ -48,7 +50,7 @@ The qualified name is `<library>:<pattern>@<tag>`. That one command:
 
 | Step | Result |
 |---|---|
-| **Copies** the pattern's file-set into `config/` | here just `detectorPlugins.ibek.support.yaml`, with a `# Vendored from … — DO NOT EDIT` header prepended |
+| **Copies** the pattern's file-set into `config/` | here just `detectorPlugins.ibek.support.yaml`, byte-for-byte as the library holds it |
 | **Pins + hashes** it in `runtime-lock.yaml` | records the `version`, `source` and a per-file `sha256` |
 | **Regenerates** the instance's `ioc.schema.json` | merges the vendored entity models into your image's schema, so the editor validates the new entity |
 
@@ -56,6 +58,15 @@ The qualified name is `<library>:<pattern>@<tag>`. That one command:
 `runtime-lock.yaml` is written at the **instance root**, not inside `config/`.
 Only `config/` is mounted into the container, so it stays the small
 runtime-input bundle; the lock is developer-side metadata.
+:::
+
+:::{warning}
+**Never hand-edit a vendored file.** A vendored copy is indistinguishable from
+any other file in `config/` — it carries no marker of its own — so
+`runtime-lock.yaml` is the only thing that says which files are copies. Anything
+it lists belongs to the library: change it there, publish a new tag and
+re-vendor. An edit made in `config/` is lost at the next `update` or `restore`,
+and fails `ibek pattern check` before that.
 :::
 
 ### The local `ioc.schema.json`
@@ -149,19 +160,55 @@ camera — statistics, ROI-statistics, HDF5 file writer and PVA.
 
 ## Check what your IOC is running
 
-Because every vendored file is hashed in `runtime-lock.yaml`, "what support is
-this IOC running?" is answerable from git with certainty. Re-verify the
-vendored files against their pins at any time — ideal in CI or a pre-commit
-hook:
+The lock is the record. `services/bl01t-ea-cam-01/runtime-lock.yaml` now reads:
+
+```yaml
+version: 1
+patterns:
+  detectorPlugins:
+    version: v0.1.0
+    source: github.com/epics-containers/ibek-runtime-support
+    files:
+      config/detectorPlugins.ibek.support.yaml: sha256:…
+```
+
+Each key under `files:` is a path **relative to the instance root** — which is
+why `config/` is part of it — so the lock names exactly which files under
+`config/` came from the library. "What support is this IOC running?" is
+answerable from git with certainty. Re-verify the vendored files against their
+pins at any time:
 
 ```bash
 ibek pattern check services/bl01t-ea-cam-01
 ```
 
-It re-hashes each file and exits non-zero on any drift. To move to a newer
-release later,
+It re-hashes each file and exits non-zero on any drift. Wire it into a
+pre-commit hook and into CI for any services repo you run in production — the
+Kubernetes services template already runs it from both. Since a vendored copy
+says nothing about itself, that check is the only thing standing between a
+well-meant edit and an IOC quietly running support that exists in no library.
+
+To move to a newer release later,
 `ibek pattern update services/bl01t-ea-cam-01 --name detectorPlugins -v <tag>`
 re-pins and refreshes the hashes.
+
+:::{note}
+**One-off migration.** A `runtime-lock.yaml` written before this format has no
+`version:`/`patterns:` wrapper, keys its files relative to `config/` rather than
+to the instance root, and its hashes cover a `DO NOT EDIT` header that vendored
+files no longer carry. `ibek pattern check` reports every file as missing and
+names the fix: run
+
+```bash
+ibek pattern update services/<instance>
+```
+
+once, with **no `--name`**, so every pattern is re-vendored at its pinned version
+and the whole lock is rewritten in the current format. The vendored files change
+too — one line shorter, the header going away — so commit them with the lock.
+It is a one-off per instance; {any}`legacy-runtime-lock` has the error messages
+in full.
+:::
 
 ## Commit
 

--- a/docs/tutorials/stream_device.md
+++ b/docs/tutorials/stream_device.md
@@ -49,16 +49,18 @@ ibek pattern add ibek-runtime-streamdevice:lakeshore340@0.1.1 services/bl01t-ea-
 ```
 
 :::{note}
-`ibek pattern` needs **ibek ≥ 4.6.2**. If it is not on your `PATH`, add it with
-`uv tool install 'ibek>=4.6.2'`.
+`ibek pattern` needs an **ibek newer than 4.6.2** — 4.6.2 and earlier stamp a
+`DO NOT EDIT` header into each vendored file and write an older
+`runtime-lock.yaml` format. If it is not on your `PATH`, add it with
+`uv tool install 'ibek>4.6.2'`.
 :::
 
 `ibek-runtime-streamdevice` is one of ibek's built-in libraries, resolved from
 its name to
 [its GitHub repo](https://github.com/epics-containers/ibek-runtime-streamdevice).
-The command vendors three files into `config/` — each with a
-`# Vendored … DO NOT EDIT` header — and writes a `runtime-lock.yaml` at the
-instance root:
+The command vendors three files into `config/` — exact copies of the library's,
+with nothing added to them — and writes a `runtime-lock.yaml` at the instance
+root:
 
 | File | Role |
 |---|---|
@@ -67,8 +69,16 @@ instance root:
 | `config/lakeshore340.template` | The EPICS database of temperature/heater records. |
 | `runtime-lock.yaml` | Pins the version and the per-file SHA-256 hashes. |
 
-Commit the lock with the instance. Anyone can later confirm the vendored files
-are untampered with:
+Three files, because that is everything the `lakeshore340` folder holds. A
+pattern whose folder also holds files an IOC has no use for — a `README`, device
+documentation, calibration notes — declares the runtime subset in an
+`ibek.manifest.yaml` beside them, and only that subset is vendored. Most
+patterns have no manifest and vendor everything they contain into `config/`; see
+{any}`custom_pattern` to write one.
+
+Commit the lock with the instance. It is what marks those three files as copies —
+edit them in the library, never here. Anyone can later confirm they are
+untampered with:
 
 ```bash
 ibek pattern check services/bl01t-ea-temp-01


### PR DESCRIPTION
Fixes #250

`ibek pattern` no longer stamps a `# Vendored from … — DO NOT EDIT` line into the
files it copies (epics-containers/ibek#361, PR epics-containers/ibek#363).
Vendored files are now byte-identical to the library, `runtime-lock.yaml` gains a
`version:` / `patterns:` wrapper with keys relative to the instance root rather
than to `config/`, and a pattern folder may carry an `ibek.manifest.yaml`
allow-list declaring which of its files are vendored and where. This updates the
docs for all of that.

The four pages that showed or mentioned the header no longer do. In its place the
rule is anchored on the lock, because that is now the only thing that says which
files under `config/` are copies: a vendored file is indistinguishable from one
you wrote, so `ibek pattern check` — from pre-commit and `ci_verify.sh` — is what
stands between a well-meant edit and an IOC running support that exists in no
library. The upside of the removal is documented too, in `custom_pattern` where
the reader actually has a library clone to compare against: `diff -r` of the
instance's `config/` against the pattern folder now agrees on every vendored file.

`detector_plugins` shows the lock as `RuntimeLock.save()` really writes it and
explains why `config/` is part of each key; `custom_pattern` gains a short
manifest section (allow-list, `dest: config`, and the fact that most patterns have
no manifest and vendor everything exactly as before); `stream_device` explains in
three sentences why `lakeshore340` vendors exactly three files. `dest`
backreference substitutions are deliberately left out, per the issue. Every
command line still says `services/<instance>` — the CLI argument was renamed to
`DEST` but it is positional, so nothing documented changed.

The migration gets its own troubleshooting entry, quoting both error texts
verbatim (the `check` "missing vendored file" run and the `add` / `update --name`
refusal) with the one fix: `ibek pattern update services/<instance>`, no `--name`.
`how-to/copier_update.md` links to it, since a repo taking a major template update
is exactly who has an old lock.

Reviewer findings acted on: the three tutorials stated ibek minimums (4.6.1 /
4.6.2) that predate every behaviour they now describe; the example manifest
omitted `.pvi.device.yaml` although the same page says a pattern may ship one;
`src` was described as "matched against" a path when `plan_vendor` uses
`re.fullmatch`; "a narrowed manifest takes effect at the next update" ignored that
a bare `update` re-fetches the pinned version; `copier_update.md` had no route to
the migration; and `DOCS-REVIEW.md` still prescribed writing about the header on
pages not yet written.

Verified against the implementation on `pattern-manifest` rather than the issue
text: the lock YAML was produced by running `RuntimeLock.save()`, the error
messages by running `vendor.check` / `vendor.add` against a legacy lock, and the
example manifest by running `plan_vendor` over a fixture pattern (it vendors the
support yaml, `.proto`, `.protocol`, `.template`, `.db`, `.req` and
`.pvi.device.yaml`, and leaves `README.md` and `docs/` behind). `sphinx-build
--fail-on-warning` is clean and `pre-commit run --all-files` passes.

## Please review

- **The version constraints are the one thing I could not pin down.** The manifest
  and lock-format work is unreleased — 4.6.2 is the latest tag and does not
  contain it — so I replaced "≥ 4.6.1" / "≥ 4.6.2" with "newer than 4.6.2"
  (`uv tool install 'ibek>4.6.2'`, `uvx --from 'ibek>4.6.2'`) rather than invent a
  tag. If you would rather name the release, three spots need it:
  `detector_plugins.md`, `custom_pattern.md`, `stream_device.md`. Merging this
  before the ibek release publishes docs for behaviour nobody can install yet.
- **Enforcement wording differs by track on purpose.** `services-template-helm`
  wires `ibek pattern check` into both `.pre-commit-config.yaml` and
  `ci_verify.sh`; `services-template-compose` — the t01 repo the tutorials build —
  has neither. So the compose pages say "wire it into a pre-commit hook and into
  CI … the Kubernetes services template already runs it from both", while
  `add_k8s_ioc.md` states it outright. Worth a second opinion on whether the
  compose template should grow the hook instead.
- **`DOCS-REVIEW.md` is an audit snapshot and I edited it.** Only the **Fix**
  prescriptions that named the header, plus a dated note at the top explaining
  why they read differently from the findings above them. Say the word and I will
  revert it and leave the file as the historical record it was.
- **The ADRs named in the issue are ibek's, not this repo's.** `0003` / `0004`
  here are "Use of substitution files" and "How to configure autosave"; the ones
  that described the header already carry `Amendment (ibek#361)` sections on the
  `pattern-manifest` branch, so nothing was needed on this side.
- One reviewer read the missing `.pvi.device.yaml` as a boot failure. It is
  narrower than that — `runtime_cmds` looks in `config/` ahead of `PVI_DEFS`, so a
  pattern's screen descriptor going missing loses the override (or the screen, if
  `PVI_DEFS` has no copy) rather than stopping the IOC. The example manifest lists
  it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vendoring guidance to explain byte-identical files, lock-file verification, manifest filtering, and re-vendoring workflows.
  * Added migration instructions for legacy lock files, including the required pattern update step.
  * Clarified that vendored files should not be edited manually and that lock files are authoritative.
  * Expanded tutorials with current commands, path and hash behavior, CI/pre-commit checks, and runtime-support ownership guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->